### PR TITLE
Support of Unicode characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG.md
+
+# 0.1 (2025-01-09)
+
+* fix: ODBCStatement >> Execute: now supports SQL request with Unicode characters,
+* fix: ODBCColumn >> stringFromBuffer now supports SQL columns with Unicode Characters.  

--- a/ODBC.pck.st
+++ b/ODBC.pck.st
@@ -1,6 +1,6 @@
-'From Cuis7.3 [latest update: #6989] on 17 January 2025 at 11:47:29 am'!
+'From Cuis7.6 [latest update: #7777] on 13 January 2026 at 6:07:58 pm'!
 'Description '!
-!provides: 'ODBC' 1 10!
+!provides: 'ODBC' 1 11!
 !requires: 'FFI' 1 40 nil!
 SystemOrganization addCategory: #'ODBC-Constants'!
 SystemOrganization addCategory: #'ODBC-Core'!
@@ -15,56 +15,6 @@ SharedPool subclass: #ODBCConstants
 	category: 'ODBC-Constants'!
 !classDefinition: 'ODBCConstants class' category: #'ODBC-Constants'!
 ODBCConstants class
-	instanceVariableNames: ''!
-
-!classDefinition: #ODBCResultTable category: #'ODBC-Core'!
-OrderedCollection subclass: #ODBCResultTable
-	instanceVariableNames: 'columns preferredColumnWidths extraLinkBlock extraLinkTitle columnPrintBlock'
-	classVariableNames: ''
-	poolDictionaries: ''
-	category: 'ODBC-Core'!
-!classDefinition: 'ODBCResultTable class' category: #'ODBC-Core'!
-ODBCResultTable class
-	instanceVariableNames: ''!
-
-!classDefinition: #ODBCRow category: #'ODBC-Core'!
-IdentityDictionary subclass: #ODBCRow
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: 'ODBCConstants'
-	category: 'ODBC-Core'!
-!classDefinition: 'ODBCRow class' category: #'ODBC-Core'!
-ODBCRow class
-	instanceVariableNames: ''!
-
-!classDefinition: #ODBCResultSet category: #'ODBC-Core'!
-Stream subclass: #ODBCResultSet
-	instanceVariableNames: 'connection statement handle columns nextRow'
-	classVariableNames: ''
-	poolDictionaries: 'ODBCConstants'
-	category: 'ODBC-Core'!
-!classDefinition: 'ODBCResultSet class' category: #'ODBC-Core'!
-ODBCResultSet class
-	instanceVariableNames: ''!
-
-!classDefinition: #ODBCError category: #'ODBC-Core'!
-Error subclass: #ODBCError
-	instanceVariableNames: 'details'
-	classVariableNames: ''
-	poolDictionaries: 'ODBCConstants'
-	category: 'ODBC-Core'!
-!classDefinition: 'ODBCError class' category: #'ODBC-Core'!
-ODBCError class
-	instanceVariableNames: ''!
-
-!classDefinition: #ODBCWarning category: #'ODBC-Core'!
-Notification subclass: #ODBCWarning
-	instanceVariableNames: 'details'
-	classVariableNames: ''
-	poolDictionaries: 'ODBCConstants'
-	category: 'ODBC-Core'!
-!classDefinition: 'ODBCWarning class' category: #'ODBC-Core'!
-ODBCWarning class
 	instanceVariableNames: ''!
 
 !classDefinition: #ODBCLibrary category: #'ODBC-Support'!
@@ -207,6 +157,56 @@ ExternalStructure subclass: #SQLUInteger
 SQLUInteger class
 	instanceVariableNames: ''!
 
+!classDefinition: #ODBCResultTable category: #'ODBC-Core'!
+OrderedCollection subclass: #ODBCResultTable
+	instanceVariableNames: 'columns preferredColumnWidths extraLinkBlock extraLinkTitle columnPrintBlock'
+	classVariableNames: ''
+	poolDictionaries: ''
+	category: 'ODBC-Core'!
+!classDefinition: 'ODBCResultTable class' category: #'ODBC-Core'!
+ODBCResultTable class
+	instanceVariableNames: ''!
+
+!classDefinition: #ODBCRow category: #'ODBC-Core'!
+IdentityDictionary subclass: #ODBCRow
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: 'ODBCConstants'
+	category: 'ODBC-Core'!
+!classDefinition: 'ODBCRow class' category: #'ODBC-Core'!
+ODBCRow class
+	instanceVariableNames: ''!
+
+!classDefinition: #ODBCResultSet category: #'ODBC-Core'!
+Stream subclass: #ODBCResultSet
+	instanceVariableNames: 'connection statement handle columns nextRow'
+	classVariableNames: ''
+	poolDictionaries: 'ODBCConstants'
+	category: 'ODBC-Core'!
+!classDefinition: 'ODBCResultSet class' category: #'ODBC-Core'!
+ODBCResultSet class
+	instanceVariableNames: ''!
+
+!classDefinition: #ODBCWarning category: #'ODBC-Core'!
+Notification subclass: #ODBCWarning
+	instanceVariableNames: 'details'
+	classVariableNames: ''
+	poolDictionaries: 'ODBCConstants'
+	category: 'ODBC-Core'!
+!classDefinition: 'ODBCWarning class' category: #'ODBC-Core'!
+ODBCWarning class
+	instanceVariableNames: ''!
+
+!classDefinition: #ODBCError category: #'ODBC-Core'!
+Error subclass: #ODBCError
+	instanceVariableNames: 'details'
+	classVariableNames: ''
+	poolDictionaries: 'ODBCConstants'
+	category: 'ODBC-Core'!
+!classDefinition: 'ODBCError class' category: #'ODBC-Core'!
+ODBCError class
+	instanceVariableNames: ''!
+
 !classDefinition: #ODBCBoundParameter category: #'ODBC-Core'!
 Object subclass: #ODBCBoundParameter
 	instanceVariableNames: 'data cType sqlType colWidth digits size'
@@ -281,7 +281,7 @@ ODBCPreparedStatement class
 !ODBCBoundParameter commentStamp: '<historical>' prior: 0!
 A bound parameter for an ODBC query.!
 
-!ODBCConstants class methodsFor: 'class initialization' stamp: 'ar 8/10/2008 17:46'!
+!ODBCConstants class methodsFor: 'class initialization' stamp: 'ar 10/Aug/2008 17:46:00'!
 initialize
 	"Initialize the pool"
 	BUFFERSIZE := (1024 * 8).
@@ -316,12 +316,806 @@ initialize
 	SQLVARCHAR := 12.
 ! !
 
-!ODBCResultTable methodsFor: 'adding' stamp: 'rjl 9/4/2008 16:06'!
+!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 14/Nov/2023 17:19:58'!
+sqlAllocConnectEnvironment: environmentHandle connection: connectionHandle 
+	"SQLRETURN
+	SQLAllocConnect(
+	SQLHENV EnvironmentHandle, 
+	SQLHDBC *ConnectionHandle);"
+	<cdecl: int16 'SQLAllocConnect' (SQLHENV SQLHDBC*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 14/Nov/2023 17:20:02'!
+sqlConnect: connectionHandle dsn: dsnString dsnLength: dsnLengthInteger user: userString userLength: userLengthInteger authentication: authenticationString authenticationLength: authenticationLengthInteger 
+	"SQLRETURN
+	SQLConnect(SQLHDBC ConnectionHandle, 
+	SQLCHAR *ServerName, 
+	SQLSMALLINT NameLength1, 
+	SQLCHAR *UserName, 
+	SQLSMALLINT NameLength2, 
+	SQLCHAR *Authentication, 
+	SQLSMALLINT NameLength3);"
+	<cdecl: int16 'SQLConnect' (SQLHDBC uint8* int16 uint8* int16 uint8* int16)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 14/Nov/2023 17:20:08'!
+sqlDisconnect: connectionHandle 
+	"SQLRETURN SQLDisconnect(SQLHDBC ConnectionHandle);"
+	<cdecl: int16 'SQLDisconnect' (SQLHDBC)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 14/Nov/2023 17:40:03'!
+sqlDriverConnect: connectionHandle with: hWnd with: inConnStr with: inStrLength with: outConnStr with: outStrLength with: outSizePtr with: flags 
+	"SQLRETURN SQLDriverConnect(
+		SQLHDBC     ConnectionHandle,
+		SQLHWND     WindowHandle,
+		SQLCHAR *     InConnectionString,
+		SQLSMALLINT     StringLength1,
+		SQLCHAR *     OutConnectionString,
+		SQLSMALLINT     BufferLength,
+		SQLSMALLINT *     StringLength2Ptr,
+		SQLUSMALLINT     DriverCompletion);"
+	<cdecl: int16 'SQLDriverConnect' (SQLHDBC void* uint8* int16 uint8* int16 SQLSmallInteger* uint3264)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 14/Nov/2023 17:26:04'!
+sqlEndTran: type handle: aHandle completionType: completionType
+	"SQLRETURN
+	SQLEndTran(
+	SQLSMALLINT HandleType,
+	SQLHANDLE Handle,
+     SQLSMALLINT CompletionType);"
+	<cdecl: int16 'SQLEndTran' (int16 SQLHDBC int16)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 14/Nov/2023 17:20:27'!
+sqlFreeConnect: connectionHandle 
+	"SQLRETURN SQLFreeConnect(SQLHDBC ConnectionHandle);"
+	<cdecl: int16 'SQLFreeConnect' (SQLHDBC)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 14/Nov/2023 17:30:33'!
+sqlGetConnectAttr: connectionHandle attribute: attribute value: value length: length valueLength: valueLength
+	"SQLRETURN SQLGetConnectAttr(
+     SQLHDBC     ConnectionHandle,
+     SQLINTEGER     Attribute,
+     SQLPOINTER     ValuePtr,
+     SQLINTEGER     BufferLength,
+     SQLINTEGER *     StringLengthPtr);"
+	<cdecl: int16 'SQLGetConnectAttr' (SQLHDBC int3264 void* int3264 SQLInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 14/Nov/2023 17:21:01'!
+sqlGetInfo: hdbc with: infoType with: resultPtr with: size with: resultLenPtr
+	"SQLRETURN SQLGetInfo(
+		SQLHDBC     ConnectionHandle,
+		SQLUSMALLINT     InfoType,
+		SQLPOINTER     InfoValuePtr,
+		SQLSMALLINT     BufferLength,
+		SQLSMALLINT *     StringLengthPtr);"
+	<cdecl: int16 'SQLGetInfo' (SQLHDBC uint16 void* int16 SQLSmallInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 14/Nov/2023 17:30:45'!
+sqlSetConnectAttr: connectionHandle attribute: attribute value: value length: length 
+	"SQLRETURN SQLSetConnectAttr(  
+	SQLHDBC ConnectionHandle,  
+	SQLINTEGER Attribute,  
+	SQLPOINTER ValuePtr,  
+	SQLINTEGER StringLength);"
+	<cdecl: int16 'SQLSetConnectAttr' (SQLHDBC int3264 int3264 int3264)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - environments' stamp: 'jfr 14/Nov/2023 17:21:25'!
+sqlAllocEnv: environmentHandle 
+	"SQLRETURN SQLAllocEnv(SQLHENV *EnvironmentHandle);"
+	<cdecl: int16 'SQLAllocEnv' (SQLHENV*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - environments' stamp: 'jfr 14/Nov/2023 17:21:32'!
+sqlFreeEnv: environmentHandle 
+	"SQLRETURN SQLFreeEnv(SQLHENV EnvironmentHandle);"
+	<cdecl: int16 'SQLFreeEnv' (SQLHENV)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - environments' stamp: 'jfr 14/Nov/2023 17:30:57'!
+sqlSetEnvAttr: hEnv attr: attr value: value length: length 
+	"SQLRETURN SQLSetEnvAttr(
+		SQLHENV     EnvironmentHandle,
+		SQLINTEGER     Attribute,
+		SQLPOINTER     ValuePtr,
+		SQLINTEGER     StringLength);"
+	<cdecl: int16 'SQLSetEnvAttr' (SQLHENV int3264 int3264 int3264)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - environments' stamp: 'jfr 14/Nov/2023 17:31:04'!
+sqlSetEnvAttrPtr: hEnv attr: attr value: value length: length 
+	"SQLRETURN SQLSetEnvAttr(
+		SQLHENV     EnvironmentHandle,
+		SQLINTEGER     Attribute,
+		SQLPOINTER     ValuePtr,
+		SQLINTEGER     StringLength);"
+	<cdecl: int16 'SQLSetEnvAttr' (SQLHENV int3264 void* int3264)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:21:57'!
+sqlAllocStmtConnection: environmentHandle statement: statementHandle 
+	"SQLRETURN
+	SQLAllocStmt(
+	SQLHDBC ConnectionHandle,
+	SQLHSTMT *StatementHandle); "
+	<cdecl: int16 'SQLAllocStmt' (SQLHDBC SQLHSTMT*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:31:13'!
+sqlBindCol: statementHandle columnNumber: columnNumber targetType: targetType targetValue: targetValue bufferLength: bufferLength strLength: strLenght 
+	"SQLRETURN  
+	SQLGetData(  
+	SQLHSTMT StatementHandle,  
+	SQLUSMALLINT ColumnNumber, 
+	SQLSMALLINT TargetType,  
+	SQLPOINTER TargetValue, 
+	SQLINTEGER BufferLength,  
+	SQLINTEGER *StrLen:=or:=Ind);"
+	<cdecl: int16 'SQLBindCol' (SQLHSTMT uint16 int16 void* int3264 SQLInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:31:21'!
+sqlBindParam: statementHandle at: paramIdx appType: dtype sqlType: ptype columSize: sz digits: digits value: vptr length: lenPtr
+	"SQLRETURN  SQL_API SQLBindParam(
+		SQLHSTMT StatementHandle,
+		SQLUSMALLINT ParameterNumber, 
+		SQLSMALLINT ValueType,
+		SQLSMALLINT ParameterType, 
+		SQLULEN LengthPrecision,
+		SQLSMALLINT ParameterScale, 
+		SQLPOINTER ParameterValue,
+		SQLLEN *StrLen_or_Ind);"
+	<cdecl: int16 'SQLBindParam' (SQLHSTMT uint16 int16 int16 uint3264 int16 void* SQLInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:31:31'!
+sqlBindParameter: statementHandle at: paramIdx ioType: ioType valueType: dtype paramType: ptype columSize: sz digits: digits value: vptr bufferSize: bfsz length: lenPtr
+	"SQLRETURN SQL_API SQLBindParameter(
+		SQLHSTMT		hstmt,
+		SQLUSMALLINT	ipar,
+		SQLSMALLINT	fParamType,
+		SQLSMALLINT	fCType,
+		SQLSMALLINT	fSqlType,
+		SQLULEN		cbColDef,
+		SQLSMALLINT	ibScale,
+		SQLPOINTER	rgbValue,
+		SQLLEN			cbValueMax,
+		SQLLEN			*pcbValue);"
+	<cdecl: int16 'SQLBindParam' (SQLHSTMT uint16 int16 int16 int16 uint3264 int16 void* int3264 SQLInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:23:05'!
+sqlDescribeParam: statementHandle at: paramIdx dataType: typePtr paramSize: lengthPtr digits: scalePtr nullable: nullable
+	"SQLRETURN SQL_API SQLDescribeParam(
+		SQLHSTMT		hstmt,
+		SQLUSMALLINT	ipar,
+		SQLSMALLINT	*pfSqlType,
+		SQLULEN		*pcbParamDef,
+		SQLSMALLINT	*pibScale,
+		SQLSMALLINT	*pfNullable);"
+	<cdecl: int16 'SQLDescribeParam' (SQLHSTMT uint16 SQLSmallInteger* SQLInteger* SQLSmallInteger* SQLSmallInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:35:16'!
+sqlExecDirect: statementHandle statement: statementString length: statementLength 
+	"SQLRETURN
+	SQLExecDirect(
+	SQLHSTMT StatementHandle,
+ 	SQLCHAR *StatementText,
+	SQLINTEGER TextLength);"
+	<cdecl: int16 'SQLExecDirect' (SQLHSTMT uint8* int3264)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:23:26'!
+sqlExecute: hstmt
+	"SQLRETURN SQL_API SQLExecute(
+		SQLHSTMT		hstmt);"
+	<cdecl: int16 'SQLExecute' (SQLHSTMT)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:23:33'!
+sqlFetch: statementHandle 
+	"SQLRETURN SQLFetch(SQLHSTMT StatementHandle);"
+	<cdecl: int16 'SQLFetch' (SQLHSTMT)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:23:43'!
+sqlFreeStmt: statementHandle option: optionInteger 
+	"SQLRETURN
+	SQLFreeStmt(
+	SQLHSTMT StatementHandle,
+	SQLUSMALLINT Option); "
+	<cdecl: int16 'SQLFreeStmt' (SQLHSTMT uint16)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:31:51'!
+sqlGetData: statementHandle columnNumber: columnNumber targetType: targetType targetValue: targetValue bufferLength: bufferLength strLength: strLenght 
+	"SQLRETURN 
+	SQLGetData( 
+	SQLHSTMT StatementHandle, 
+	SQLUSMALLINT ColumnNumber,
+	SQLSMALLINT TargetType, 
+	SQLPOINTER TargetValue,
+	SQLINTEGER BufferLength, 
+	SQLINTEGER *StrLen:=or:=Ind);"
+	<cdecl: int16 'SQLGetData' (SQLHSTMT uint3264 int16 void* int3264 SQLInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:24:04'!
+sqlGetTypeInfo: hstmt with: dataType
+	"SQLRETURN SQLGetTypeInfo(
+		SQLHSTMT     StatementHandle,
+		SQLSMALLINT     DataType);"
+	<cdecl: int16 'SQLGetTypeInfo' (SQLHSTMT uint16)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:24:12'!
+sqlNumParams: statementHandle into: shortArray
+	"SQLRETURN
+	SQLNumParams(
+	SQLHSTMT StatementHandle,
+ 	SQLSMALLINT *pcpar);"
+	<cdecl: int16 'SQLNumParams' (SQLHSTMT SQLSmallInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:35:30'!
+sqlPrepare: statementHandle statement: statementString length: statementLength 
+	"SQLRETURN
+	SQLPrepare(
+	SQLHSTMT StatementHandle,
+ 	SQLCHAR *StatementText,
+	SQLINTEGER TextLength);"
+	<cdecl: int16 'SQLPrepare' (SQLHSTMT uint8* int3264)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:32:11'!
+sqlSetStmtAttr: statementHandle name: attr value: value length: length
+	"NOTE: Use sqlSetStmtAttrPtr: if you need to pass a pointer for the value."
+	"SQLRETURN  SQL_API SQLSetStmtAttr(
+		SQLHSTMT StatementHandle,
+		SQLINTEGER Attribute, 
+		SQLPOINTER Value,
+		SQLINTEGER StringLength);"
+	<cdecl: int16 'SQLSetStmtAttr' (SQLHSTMT int3264 uint3264 int3264)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:32:19'!
+sqlSetStmtAttrPtr: statementHandle name: attr value: value length: length
+	"SQLRETURN  SQL_API SQLSetStmtAttr(
+		SQLHSTMT StatementHandle,
+		SQLINTEGER Attribute, 
+		SQLPOINTER Value,
+		SQLINTEGER StringLength);"
+	<cdecl: int16 'SQLSetStmtAttr' (SQLHSTMT int3264 void* int3264)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 14/Nov/2023 17:29:57'!
+sqlSetStmtOption: statementHandle name: attr value: value
+	"SQLRETURN  SQL_API SQLSetStmtOption(
+		SQLHSTMT StatementHandle,
+		SQLUSMALLINT Option, 
+		SQLROWCOUNT Value);"
+	<cdecl: int16 'SQLSetStmtOption' (SQLHSTMT uint16 uint3264)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - resultset' stamp: 'jfr 14/Nov/2023 17:25:05'!
+sqlDescribeCol: statementHandle columnNumber: columnCount columnName: columnName bufferLength: bufferLength nameLength: nameLength dataType: dataType columnSize: columnSize decimalDigits: decimalDigits nullable: nullable 
+	"SQLRETURN
+	SQLDescribeCol(
+	SQLHSTMT StatementHandle, 
+	SQLUSMALLINT ColumnNumber,
+	SQLCHAR *ColumnName, 
+	SQLSMALLINT BufferLength,
+	SQLSMALLINT *NameLength, 
+	SQLSMALLINT *DataType,
+	SQLUINTEGER *ColumnSize, 
+	SQLSMALLINT *DecimalDigits,
+	SQLSMALLINT *Nullable);"
+	<cdecl: int16 'SQLDescribeCol' (SQLHSTMT uint16 void* int16 SQLSmallInteger* SQLSmallInteger* SQLUInteger* SQLSmallInteger* SQLSmallInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - resultset' stamp: 'jfr 14/Nov/2023 17:25:12'!
+sqlNumResultCols: statementHandle columnCount: columnCount 
+	"SQLRETURN
+	SQLNumResultCols(
+	SQLHSTMT StatementHandle,
+	SQLSMALLINT *ColumnCount); "
+	<cdecl: int16 'SQLNumResultCols' (SQLHSTMT SQLSmallInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - resultset' stamp: 'jfr 14/Nov/2023 17:25:19'!
+sqlRowCount: statementHandle rowCount: rowCount 
+	"SQLRETURN
+	SQLRowCount(
+	SQLHSTMT StatementHandle,
+	SQLSMALLINT *RowCount); "
+	<cdecl: int16 'SQLRowCount' (SQLHSTMT SQLSmallInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary methodsFor: 'primitives - errors' stamp: 'jfr 14/Nov/2023 17:25:37'!
+sqlErrorEnvironment: environmentHandle connection: connectionHandle statement: statementHandle state: stateString nativeError: nativeError messateText: messateTextString bufferLength: bufferLengthInteger textLength: textLenghtInteger 
+	"SQLRETURN
+	SQLError(
+	SQLHENV EnvironmentHandle, 
+	SQLHDBC ConnectionHandle,
+	SQLHSTMT StatementHandle, 
+	SQLCHAR *Sqlstate,
+	SQLINTEGER *NativeError, 
+	SQLCHAR *MessageText,
+	SQLSMALLINT BufferLength, 
+	SQLSMALLINT *TextLength);"
+	<cdecl: int16 'SQLError' (SQLHENV SQLHDBC SQLHSTMT void* SQLInteger* void* int16 SQLSmallInteger*)>
+	^ self externalCallFailed! !
+
+!ODBCLibrary class methodsFor: 'instance creation' stamp: 'jfr 14/Nov/2023 17:11:51'!
+default
+	"Answer the singleton"
+	^default ifNil:[default := super new]! !
+
+!ODBCLibrary class methodsFor: 'instance creation' stamp: 'jfr 14/Nov/2023 13:58:22'!
+initialize
+	"Initialize the class"
+	default := nil.! !
+
+!ODBCLibrary class methodsFor: 'instance creation' stamp: 'jfr 14/Nov/2023 13:49:07'!
+moduleName
+	"Return the name of the module for this library"
+	Smalltalk platformName = 'Win32' ifTrue: [ ^ 'odbc32' ].
+	Smalltalk platformName = 'unix' ifTrue: [ ^ 'libodbc.so' ].
+	Smalltalk platformName = 'Mac OS' ifTrue: [ ^ 'libodbc.dylib' ].
+	^ self error: 'Don''t know the ODBC library name'! !
+
+!ODBCLibrary class methodsFor: 'instance creation' stamp: 'jfr 14/Nov/2023 13:50:02'!
+new
+	^ self error:'use #default'! !
+
+!SQLByte methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLByte class>>fields."
+	<generated>
+	^handle uint8At: 1! !
+
+!SQLByte methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLByte class>>fields."
+	<generated>
+	handle uint8At: 1 put: anObject! !
+
+!SQLByte class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:07:47'!
+fields
+	" 
+	SQLByte defineFields
+	"
+	^ #(#(#value 'uint8') )! !
+
+!SQLByte class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 14:00:36'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLDate methodsFor: 'accessing' stamp: ''!
+day
+	"This method was automatically generated. See SQLDate class>>fields."
+	<generated>
+	^handle uint16At: 5! !
+
+!SQLDate methodsFor: 'accessing' stamp: ''!
+day: anObject
+	"This method was automatically generated. See SQLDate class>>fields."
+	<generated>
+	handle uint16At: 5 put: anObject! !
+
+!SQLDate methodsFor: 'accessing' stamp: ''!
+month
+	"This method was automatically generated. See SQLDate class>>fields."
+	<generated>
+	^handle uint16At: 3! !
+
+!SQLDate methodsFor: 'accessing' stamp: ''!
+month: anObject
+	"This method was automatically generated. See SQLDate class>>fields."
+	<generated>
+	handle uint16At: 3 put: anObject! !
+
+!SQLDate methodsFor: 'accessing' stamp: ''!
+year
+	"This method was automatically generated. See SQLDate class>>fields."
+	<generated>
+	^handle int16At: 1! !
+
+!SQLDate methodsFor: 'accessing' stamp: ''!
+year: anObject
+	"This method was automatically generated. See SQLDate class>>fields."
+	<generated>
+	handle int16At: 1 put: anObject! !
+
+!SQLDate class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:08:16'!
+fields
+	" 
+	SQLDate defineFields
+	"
+	^ #(#(#year 'int16') #(#month 'uint16') #(#day 'uint16') )! !
+
+!SQLDate class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 14:00:27'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLDouble methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLDouble class>>fields."
+	<generated>
+	^handle doubleAt: 1! !
+
+!SQLDouble methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLDouble class>>fields."
+	<generated>
+	handle doubleAt: 1 put: anObject! !
+
+!SQLDouble class methodsFor: 'accessing' stamp: 'dgd 31/May/2002 20:24:00'!
+fields
+	" 
+	SQLDouble defineFields
+	"
+	^ #(#(#value 'double') )! !
+
+!SQLDouble class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 14:00:09'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLFloat methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLFloat class>>fields."
+	<generated>
+	^handle floatAt: 1! !
+
+!SQLFloat methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLFloat class>>fields."
+	<generated>
+	handle floatAt: 1 put: anObject! !
+
+!SQLFloat class methodsFor: 'accessing' stamp: 'dgd 31/May/2002 20:23:00'!
+fields
+	" 
+	SQLFloat defineFields
+	"
+	^ #(#(#value 'float') )! !
+
+!SQLFloat class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 13:59:59'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLHDBC methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLHDBC class>>fields."
+	<generated>
+	^handle int64At: 1! !
+
+!SQLHDBC methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLHDBC class>>fields."
+	<generated>
+	handle int64At: 1 put: anObject! !
+
+!SQLHDBC class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:06:29'!
+fields
+	" 
+	SQLHDBC defineFields 
+	"
+	^ #(#(#value 'int3264') )! !
+
+!SQLHDBC class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:06:07'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLHENV methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLHENV class>>fields."
+	<generated>
+	^handle int64At: 1! !
+
+!SQLHENV methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLHENV class>>fields."
+	<generated>
+	handle int64At: 1 put: anObject! !
+
+!SQLHENV class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:05:33'!
+fields
+	" 
+	SQLHENV defineFields 
+	"
+	^ #(#(#value 'int3264') )! !
+
+!SQLHENV class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:05:06'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLHSTMT methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLHSTMT class>>fields."
+	<generated>
+	^handle int64At: 1! !
+
+!SQLHSTMT methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLHSTMT class>>fields."
+	<generated>
+	handle int64At: 1 put: anObject! !
+
+!SQLHSTMT class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:03:28'!
+fields
+	" 
+	SQLHSTMT defineFields
+	"
+	^ #(#(#value 'int3264') )! !
+
+!SQLHSTMT class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:04:05'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLInteger methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLInteger class>>fields."
+	<generated>
+	^handle int64At: 1! !
+
+!SQLInteger methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLInteger class>>fields."
+	<generated>
+	handle int64At: 1 put: anObject! !
+
+!SQLInteger class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:01:22'!
+fields
+	" 
+	SQLInteger defineFields 
+	"
+	^ #(#(#value 'int3264') )! !
+
+!SQLInteger class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 16:59:24'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLShort methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLShort class>>fields."
+	<generated>
+	^handle int16At: 1! !
+
+!SQLShort methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLShort class>>fields."
+	<generated>
+	handle int16At: 1 put: anObject! !
+
+!SQLShort class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:08:49'!
+fields
+	" 
+	SQLShort defineFields
+	"
+	^ #(#(#value 'int16') )! !
+
+!SQLShort class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 13:59:46'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLSmallInteger methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLSmallInteger class>>fields."
+	<generated>
+	^handle int16At: 1! !
+
+!SQLSmallInteger methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLSmallInteger class>>fields."
+	<generated>
+	handle int16At: 1 put: anObject! !
+
+!SQLSmallInteger class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:08:58'!
+fields
+	"
+	SQLSmallInteger defineFields
+	"
+	^#(
+		(value 'int16')
+	)
+! !
+
+!SQLSmallInteger class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 13:59:38'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLTime methodsFor: 'accessing' stamp: ''!
+hour
+	"This method was automatically generated. See SQLTime class>>fields."
+	<generated>
+	^handle uint16At: 1! !
+
+!SQLTime methodsFor: 'accessing' stamp: ''!
+hour: anObject
+	"This method was automatically generated. See SQLTime class>>fields."
+	<generated>
+	handle uint16At: 1 put: anObject! !
+
+!SQLTime methodsFor: 'accessing' stamp: ''!
+minute
+	"This method was automatically generated. See SQLTime class>>fields."
+	<generated>
+	^handle uint16At: 3! !
+
+!SQLTime methodsFor: 'accessing' stamp: ''!
+minute: anObject
+	"This method was automatically generated. See SQLTime class>>fields."
+	<generated>
+	handle uint16At: 3 put: anObject! !
+
+!SQLTime methodsFor: 'accessing' stamp: ''!
+second
+	"This method was automatically generated. See SQLTime class>>fields."
+	<generated>
+	^handle uint16At: 5! !
+
+!SQLTime methodsFor: 'accessing' stamp: ''!
+second: anObject
+	"This method was automatically generated. See SQLTime class>>fields."
+	<generated>
+	handle uint16At: 5 put: anObject! !
+
+!SQLTime class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:09:10'!
+fields
+	" 
+	SQLTime defineFields
+	"
+	^ #(#(#hour 'uint16') #(#minute 'uint16') #(#second 'uint16') )! !
+
+!SQLTime class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 13:59:31'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+day
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	^handle uint16At: 5! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+day: anObject
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	handle uint16At: 5 put: anObject! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+fraction
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	^handle uint32At: 13! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+fraction: anObject
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	handle uint32At: 13 put: anObject! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+hour
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	^handle uint16At: 7! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+hour: anObject
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	handle uint16At: 7 put: anObject! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+minute
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	^handle uint16At: 9! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+minute: anObject
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	handle uint16At: 9 put: anObject! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+month
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	^handle uint16At: 3! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+month: anObject
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	handle uint16At: 3 put: anObject! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+second
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	^handle uint16At: 11! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+second: anObject
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	handle uint16At: 11 put: anObject! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+year
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	^handle int16At: 1! !
+
+!SQLTimestamp methodsFor: 'accessing' stamp: ''!
+year: anObject
+	"This method was automatically generated. See SQLTimestamp class>>fields."
+	<generated>
+	handle int16At: 1 put: anObject! !
+
+!SQLTimestamp class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 17:09:37'!
+fields
+	" 
+	SQLTimestamp defineFields
+	"
+	^ #(#(#year 'int16') #(#month 'uint16') #(#day 'uint16') #(#hour 'uint16') #(#minute 'uint16') #(#second 'uint16') #(#fraction 'uint32') )! !
+
+!SQLTimestamp class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 13:59:22'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!SQLUInteger methodsFor: 'accessing' stamp: ''!
+value
+	"This method was automatically generated. See SQLUInteger class>>fields."
+	<generated>
+	^handle uint64At: 1! !
+
+!SQLUInteger methodsFor: 'accessing' stamp: ''!
+value: anObject
+	"This method was automatically generated. See SQLUInteger class>>fields."
+	<generated>
+	handle uint64At: 1 put: anObject! !
+
+!SQLUInteger class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 16:58:34'!
+fields
+	" 
+	SQLUInteger defineFields
+	"
+	^ #(#(#value 'uint3264') )! !
+
+!SQLUInteger class methodsFor: 'accessing' stamp: 'jfr 14/Nov/2023 16:57:22'!
+initialize
+	" Initialize the class "
+	self defineFields.! !
+
+!ODBCResultTable methodsFor: 'adding' stamp: 'rjl 4/Sep/2008 16:06:00'!
 add: row 
 	self maxWidthOfColumnsForRow: row.
 	^ super add: row! !
 
-!ODBCResultTable methodsFor: 'converting' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'converting' stamp: 'rjl 4/Sep/2008 16:07:00'!
 asMorph
 	| twoWayScroller report title window |
 	report := TextMorph new
@@ -353,27 +1147,27 @@ asMorph
 		addMorph: twoWayScroller
 		fullFrame: (LayoutFrame fractions: (0 @ 0 extent: 1 @ 1))! !
 
-!ODBCResultTable methodsFor: 'converting' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'converting' stamp: 'rjl 4/Sep/2008 16:07:00'!
 openAsMorph
 	self asMorph openAsIsIn: ActiveWorld! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 columnNames
 	^ self columns collect: [ :each | each name ]! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 columnPrintBlock
 	^ columnPrintBlock ifNil: [ self standardColumnPrintBlock ]! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 columnPrintBlock: aThreeArgBlock 
 	columnPrintBlock := aThreeArgBlock! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 columns
 	^ columns! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 columns: aList 
 	columns := aList reject: 
 		[ :each | 
@@ -385,16 +1179,16 @@ columns: aList
 			#Locked
 		) includes: each name ]! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 extraLinkTitle: aString do: aOneArgumentBlock 
 	extraLinkTitle := aString.
 	extraLinkBlock := aOneArgumentBlock! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 maxWidthOfColumn: anODBCColumn 
 	^ (preferredColumnWidths at: anODBCColumn) + 2! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 maxWidthOfColumnsForRow: row 
 	self columns do: 
 		[ :each | 
@@ -406,12 +1200,12 @@ maxWidthOfColumnsForRow: row
 			at: each
 			put: (currentWidth max: (row at: each name) printString size) ]! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 preferredColumnWidths
 	"Return a list of associations so that column order is preserved"
 	^ self columns collect: [ :each | each -> (self maxWidthOfColumn: each) ]! !
 
-!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 9/4/2008 16:09'!
+!ODBCResultTable methodsFor: 'accessing' stamp: 'rjl 4/Sep/2008 16:09:00'!
 standardColumnPrintBlock
 	^ 
 	[ :row :column :textStream | 
@@ -422,11 +1216,11 @@ standardColumnPrintBlock
 			formatItem: columnValue asString
 			toWidth: column value) ]! !
 
-!ODBCResultTable methodsFor: 'initialization' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'initialization' stamp: 'rjl 4/Sep/2008 16:07:00'!
 initialize
 	preferredColumnWidths := Dictionary new! !
 
-!ODBCResultTable methodsFor: 'printing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'printing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 printHeaderOn: aStream 
 	self columns do: 
 		[ :each | 
@@ -445,7 +1239,7 @@ printHeaderOn: aStream
 			nextPut: $  ].
 	aStream cr! !
 
-!ODBCResultTable methodsFor: 'printing' stamp: 'rjl 9/4/2008 16:07'!
+!ODBCResultTable methodsFor: 'printing' stamp: 'rjl 4/Sep/2008 16:07:00'!
 printOn: aStream 
 	self printHeaderOn: aStream.
 	self do: 
@@ -455,7 +1249,7 @@ printOn: aStream
 			withColumnDefinitions: self preferredColumnWidths.
 		aStream cr ]! !
 
-!ODBCResultTable methodsFor: 'printing' stamp: 'rjl 9/4/2008 16:09'!
+!ODBCResultTable methodsFor: 'printing' stamp: 'rjl 4/Sep/2008 16:09:00'!
 printTextForRow: aRow on: aTextStream 
 	self preferredColumnWidths do: 
 		[ :each | 
@@ -471,7 +1265,7 @@ printTextForRow: aRow on: aTextStream
 		space;
 		cr! !
 
-!ODBCResultTable methodsFor: 'printing' stamp: 'rjl 9/4/2008 16:09'!
+!ODBCResultTable methodsFor: 'printing' stamp: 'rjl 4/Sep/2008 16:09:00'!
 printTextOn: aTextStream 
 	self printHeaderOn: aTextStream.
 	self do: 
@@ -480,11 +1274,11 @@ printTextOn: aTextStream
 			printTextForRow: each
 			on: aTextStream ]! !
 
-!ODBCResultTable methodsFor: 'private' stamp: 'rjl 9/4/2008 16:09'!
+!ODBCResultTable methodsFor: 'private' stamp: 'rjl 4/Sep/2008 16:09:00'!
 species
 	^ OrderedCollection! !
 
-!ODBCResultTable class methodsFor: 'formatting' stamp: 'bvs 4/14/2004 14:15'!
+!ODBCResultTable class methodsFor: 'formatting' stamp: 'bvs 14/Apr/2004 14:15:00'!
 formatItem: aString toWidth: aNumber
 
 	^ aString
@@ -492,12 +1286,12 @@ formatItem: aString toWidth: aNumber
 		to: aNumber
 		with: $ ! !
 
-!ODBCResultTable class methodsFor: 'instance creation' stamp: 'jrp 3/10/2004 13:23'!
+!ODBCResultTable class methodsFor: 'instance creation' stamp: 'jrp 10/Mar/2004 13:23:00'!
 new
 
 	^ super new initialize! !
 
-!ODBCResultTable class methodsFor: 'instance creation' stamp: 'rjl 9/4/2008 16:06'!
+!ODBCResultTable class methodsFor: 'instance creation' stamp: 'rjl 4/Sep/2008 16:06:00'!
 newFrom: anODBCResultSet 
 	| table |
 	table := self new.
@@ -506,7 +1300,7 @@ newFrom: anODBCResultSet
 	anODBCResultSet close.
 	^ table! !
 
-!ODBCRow methodsFor: 'error handling' stamp: 'rjl 9/4/2008 15:25'!
+!ODBCRow methodsFor: 'error handling' stamp: 'rjl 4/Sep/2008 15:25:00'!
 doesNotUnderstand: aMessage 
 	| originalSelector |
 	originalSelector := aMessage selector.
@@ -521,7 +1315,7 @@ doesNotUnderstand: aMessage
 			ifPresent: [ :val | ^ val ] ].
 	^ super doesNotUnderstand: aMessage! !
 
-!ODBCRow methodsFor: 'printing' stamp: 'rjl 9/4/2008 16:00'!
+!ODBCRow methodsFor: 'printing' stamp: 'rjl 4/Sep/2008 16:00:00'!
 printOn: aStream withColumnDefinitions: aList 
 	aList do: 
 		[ :each | 
@@ -529,37 +1323,37 @@ printOn: aStream withColumnDefinitions: aList
 				formatItem: (self at: each key name) asString
 				toWidth: each value) ]! !
 
-!ODBCResultSet methodsFor: 'converting' stamp: 'rjl 9/4/2008 15:59'!
+!ODBCResultSet methodsFor: 'converting' stamp: 'rjl 4/Sep/2008 15:59:00'!
 asTable
 	^ ODBCResultTable newFrom: self! !
 
-!ODBCResultSet methodsFor: 'testing' stamp: 'dgd 5/27/2002 23:14'!
+!ODBCResultSet methodsFor: 'testing' stamp: 'dgd 27/May/2002 23:14:00'!
 atEnd
 	self checkConnected.
 	^ nextRow isNil! !
 
-!ODBCResultSet methodsFor: 'testing' stamp: 'dgd 6/2/2002 21:56'!
+!ODBCResultSet methodsFor: 'testing' stamp: 'dgd 2/Jun/2002 21:56:00'!
 closed
 	"asnwer if the receiver is closed"
 	^ self isConnected not! !
 
-!ODBCResultSet methodsFor: 'testing' stamp: 'dgd 5/27/2002 23:49'!
+!ODBCResultSet methodsFor: 'testing' stamp: 'dgd 27/May/2002 23:49:00'!
 isConnected
 	"answer if the receiver is connected"
 	^ handle notNil! !
 
-!ODBCResultSet methodsFor: 'private' stamp: 'dgd 5/27/2002 23:14'!
+!ODBCResultSet methodsFor: 'private' stamp: 'dgd 27/May/2002 23:14:00'!
 checkConnected
 	"private - check if the recevier is connected"
 	self isConnected
 		ifFalse: [^ self error: 'unconnected!!']! !
 
-!ODBCResultSet methodsFor: 'private' stamp: 'dgd 5/27/2002 01:17'!
+!ODBCResultSet methodsFor: 'private' stamp: 'dgd 27/May/2002 01:17:00'!
 fetchNextRow
 	"private - fetch the next row"
 	nextRow := self fetchRow! !
 
-!ODBCResultSet methodsFor: 'connecting' stamp: 'jfr 11/13/2023 16:02:12'!
+!ODBCResultSet methodsFor: 'connecting' stamp: 'jfr 13/Nov/2023 16:02:12'!
 close
 	"close the receiver"
 	self isConnected
@@ -575,7 +1369,7 @@ columns notNil ifTrue:[
 	handle := nil.
 	self unregisterForFinalization! !
 
-!ODBCResultSet methodsFor: 'connecting' stamp: 'jfr 11/13/2023 16:02:19'!
+!ODBCResultSet methodsFor: 'connecting' stamp: 'jfr 13/Nov/2023 16:02:19'!
 closeNotFail
 	"close the receiver without signaling errors"
 	self isConnected
@@ -589,23 +1383,23 @@ columns notNil ifTrue:[
 	handle := nil.
 	self unregisterForFinalization! !
 
-!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 5/31/2002 20:20'!
+!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 31/May/2002 20:20:00'!
 columns
 	"answer the receiver's columns.
 
 	It's an array of ODBCColumns with metadata information"
 	^ columns! !
 
-!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 5/30/2002 23:42'!
+!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 30/May/2002 23:42:00'!
 connection
 	"answer the receiver's connection"
 	^ connection! !
 
-!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 5/27/2002 00:44'!
+!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 27/May/2002 00:44:00'!
 contents
 	^ self shouldNotImplement! !
 
-!ODBCResultSet methodsFor: 'accessing' stamp: 'jfr 11/13/2023 16:02:24'!
+!ODBCResultSet methodsFor: 'accessing' stamp: 'jfr 13/Nov/2023 16:02:24'!
 fetchRow
 	"private - fetch the next row"
 	| row ret |
@@ -617,11 +1411,11 @@ fetchRow
 	columns do: [:each | row at: each name put: each data]. 
 	^ row! !
 
-!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 5/29/2002 23:32'!
+!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 29/May/2002 23:32:00'!
 handle
 	^ handle! !
 
-!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 5/27/2002 23:13'!
+!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 27/May/2002 23:13:00'!
 next
 	"answer the next row, nil if none"
 	| result |
@@ -631,11 +1425,11 @@ self checkConnected.
 		ifTrue: [self fetchNextRow].
 	^ result! !
 
-!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 5/27/2002 00:45'!
+!ODBCResultSet methodsFor: 'accessing' stamp: 'dgd 27/May/2002 00:45:00'!
 nextPut: anObject 
 	^ self shouldNotImplement! !
 
-!ODBCResultSet methodsFor: 'accessing' stamp: 'jfr 11/13/2023 16:02:37'!
+!ODBCResultSet methodsFor: 'accessing' stamp: 'jfr 13/Nov/2023 16:02:37'!
 rowCount
 	"answer the receiver's rowCount
 
@@ -648,23 +1442,23 @@ rowCount
 		statement: handle.
 	^ rows value! !
 
-!ODBCResultSet methodsFor: 'private - finalization' stamp: 'dgd 5/27/2002 22:57'!
+!ODBCResultSet methodsFor: 'private - finalization' stamp: 'dgd 27/May/2002 22:57:00'!
 finalize
 	self closeNotFail! !
 
-!ODBCResultSet methodsFor: 'private - finalization' stamp: 'dgd 5/27/2002 22:58'!
+!ODBCResultSet methodsFor: 'private - finalization' stamp: 'dgd 27/May/2002 22:58:00'!
 registerForFinalization
 	"private - register the receiver to the class side registry for finalization  
 	notification"
 	connection class register: self! !
 
-!ODBCResultSet methodsFor: 'private - finalization' stamp: 'dgd 5/27/2002 22:58'!
+!ODBCResultSet methodsFor: 'private - finalization' stamp: 'dgd 27/May/2002 22:58:00'!
 unregisterForFinalization
 	"private - unregister the receiver to the class side registry for  
 	finalization notification"
 	connection class unregister: self! !
 
-!ODBCResultSet methodsFor: 'initialization' stamp: 'jfr 11/13/2023 16:02:30'!
+!ODBCResultSet methodsFor: 'initialization' stamp: 'jfr 13/Nov/2023 16:02:30'!
 initializeConnection: aConnection statement: aStatement 
 	"initialize the receiver"
 	| columnCount |
@@ -684,14 +1478,14 @@ initializeConnection: aConnection statement: aStatement
 	columns notEmpty
 		ifTrue: [self fetchNextRow]! !
 
-!ODBCResultSet methodsFor: 'printing' stamp: 'ar 8/2/2008 13:58'!
+!ODBCResultSet methodsFor: 'printing' stamp: 'ar 2/Aug/2008 13:58:00'!
 printContentsOn: stream
 	stream
 		nextPutAll: (self isConnected
 				ifTrue: [' (connected)']
 				ifFalse: [' (not connected)'])! !
 
-!ODBCResultSet methodsFor: 'printing' stamp: 'jfr 11/14/2023 16:13:24'!
+!ODBCResultSet methodsFor: 'printing' stamp: 'jfr 14/Nov/2023 16:13:24'!
 printOn: aStream
 	"Append to the argument, aStream, a sequence of characters that  
 	identifies the receiver."
@@ -700,33 +1494,15 @@ printOn: aStream
 		nextPutAll: self class name withArticle.
 	self printContentsOn: aStream.! !
 
-!ODBCResultSet class methodsFor: 'instance creation' stamp: 'dgd 5/27/2002 22:44'!
+!ODBCResultSet class methodsFor: 'instance creation' stamp: 'dgd 27/May/2002 22:44:00'!
 connection: aConnection statement: aStatement 
 	^ self basicNew initializeConnection: aConnection statement: aStatement ! !
 
-!ODBCError methodsFor: 'initialization' stamp: 'dgd 6/3/2002 19:16'!
-initializeDetails: aCollection 
-	details := aCollection.
-""
-	self messageText: self asString! !
-
-!ODBCError methodsFor: 'printing' stamp: 'dgd 6/3/2002 19:17'!
-printOn: aStream 
-	super printOn: aStream.
-aStream nextPutAll: ' '.
-	details
-		do: [:each | aStream nextPutAll: each asString]
-		separatedBy: [aStream nextPutAll: ', ']! !
-
-!ODBCError class methodsFor: 'instance creation' stamp: 'dgd 6/3/2002 19:16'!
-details: aCollection
-	^ self new initializeDetails: aCollection! !
-
-!ODBCWarning methodsFor: 'printing' stamp: 'ar 8/2/2008 15:10'!
+!ODBCWarning methodsFor: 'printing' stamp: 'ar 2/Aug/2008 15:10:00'!
 defaultAction
 	ToolSet default debugError: self! !
 
-!ODBCWarning methodsFor: 'printing' stamp: 'dgd 6/3/2002 19:18'!
+!ODBCWarning methodsFor: 'printing' stamp: 'dgd 3/Jun/2002 19:18:00'!
 printOn: aStream 
 	super printOn: aStream.
 	aStream nextPutAll: ' '.
@@ -734,867 +1510,91 @@ printOn: aStream
 		do: [:each | aStream nextPutAll: each asString]
 		separatedBy: [aStream nextPutAll: ', ']! !
 
-!ODBCWarning methodsFor: 'initialization' stamp: 'dgd 6/3/2002 19:18'!
+!ODBCWarning methodsFor: 'initialization' stamp: 'dgd 3/Jun/2002 19:18:00'!
 initializeDetails: aCollection 
 	details := aCollection.
 	""
 	self messageText: self asString! !
 
-!ODBCWarning class methodsFor: 'instance creation' stamp: 'dgd 6/3/2002 19:18'!
+!ODBCWarning class methodsFor: 'instance creation' stamp: 'dgd 3/Jun/2002 19:18:00'!
 details: aCollection 
 	^ self new initializeDetails: aCollection! !
 
-!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 11/14/2023 17:19:58'!
-sqlAllocConnectEnvironment: environmentHandle connection: connectionHandle 
-	"SQLRETURN
-	SQLAllocConnect(
-	SQLHENV EnvironmentHandle, 
-	SQLHDBC *ConnectionHandle);"
-	<cdecl: int16 'SQLAllocConnect' (SQLHENV SQLHDBC*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 11/14/2023 17:20:02'!
-sqlConnect: connectionHandle dsn: dsnString dsnLength: dsnLengthInteger user: userString userLength: userLengthInteger authentication: authenticationString authenticationLength: authenticationLengthInteger 
-	"SQLRETURN
-	SQLConnect(SQLHDBC ConnectionHandle, 
-	SQLCHAR *ServerName, 
-	SQLSMALLINT NameLength1, 
-	SQLCHAR *UserName, 
-	SQLSMALLINT NameLength2, 
-	SQLCHAR *Authentication, 
-	SQLSMALLINT NameLength3);"
-	<cdecl: int16 'SQLConnect' (SQLHDBC uint8* int16 uint8* int16 uint8* int16)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 11/14/2023 17:20:08'!
-sqlDisconnect: connectionHandle 
-	"SQLRETURN SQLDisconnect(SQLHDBC ConnectionHandle);"
-	<cdecl: int16 'SQLDisconnect' (SQLHDBC)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 11/14/2023 17:40:03'!
-sqlDriverConnect: connectionHandle with: hWnd with: inConnStr with: inStrLength with: outConnStr with: outStrLength with: outSizePtr with: flags 
-	"SQLRETURN SQLDriverConnect(
-		SQLHDBC     ConnectionHandle,
-		SQLHWND     WindowHandle,
-		SQLCHAR *     InConnectionString,
-		SQLSMALLINT     StringLength1,
-		SQLCHAR *     OutConnectionString,
-		SQLSMALLINT     BufferLength,
-		SQLSMALLINT *     StringLength2Ptr,
-		SQLUSMALLINT     DriverCompletion);"
-	<cdecl: int16 'SQLDriverConnect' (SQLHDBC void* uint8* int16 uint8* int16 SQLSmallInteger* uint3264)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 11/14/2023 17:26:04'!
-sqlEndTran: type handle: aHandle completionType: completionType
-	"SQLRETURN
-	SQLEndTran(
-	SQLSMALLINT HandleType,
-	SQLHANDLE Handle,
-     SQLSMALLINT CompletionType);"
-	<cdecl: int16 'SQLEndTran' (int16 SQLHDBC int16)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 11/14/2023 17:20:27'!
-sqlFreeConnect: connectionHandle 
-	"SQLRETURN SQLFreeConnect(SQLHDBC ConnectionHandle);"
-	<cdecl: int16 'SQLFreeConnect' (SQLHDBC)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 11/14/2023 17:30:33'!
-sqlGetConnectAttr: connectionHandle attribute: attribute value: value length: length valueLength: valueLength
-	"SQLRETURN SQLGetConnectAttr(
-     SQLHDBC     ConnectionHandle,
-     SQLINTEGER     Attribute,
-     SQLPOINTER     ValuePtr,
-     SQLINTEGER     BufferLength,
-     SQLINTEGER *     StringLengthPtr);"
-	<cdecl: int16 'SQLGetConnectAttr' (SQLHDBC int3264 void* int3264 SQLInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 11/14/2023 17:21:01'!
-sqlGetInfo: hdbc with: infoType with: resultPtr with: size with: resultLenPtr
-	"SQLRETURN SQLGetInfo(
-		SQLHDBC     ConnectionHandle,
-		SQLUSMALLINT     InfoType,
-		SQLPOINTER     InfoValuePtr,
-		SQLSMALLINT     BufferLength,
-		SQLSMALLINT *     StringLengthPtr);"
-	<cdecl: int16 'SQLGetInfo' (SQLHDBC uint16 void* int16 SQLSmallInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - connections' stamp: 'jfr 11/14/2023 17:30:45'!
-sqlSetConnectAttr: connectionHandle attribute: attribute value: value length: length 
-	"SQLRETURN SQLSetConnectAttr(  
-	SQLHDBC ConnectionHandle,  
-	SQLINTEGER Attribute,  
-	SQLPOINTER ValuePtr,  
-	SQLINTEGER StringLength);"
-	<cdecl: int16 'SQLSetConnectAttr' (SQLHDBC int3264 int3264 int3264)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - environments' stamp: 'jfr 11/14/2023 17:21:25'!
-sqlAllocEnv: environmentHandle 
-	"SQLRETURN SQLAllocEnv(SQLHENV *EnvironmentHandle);"
-	<cdecl: int16 'SQLAllocEnv' (SQLHENV*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - environments' stamp: 'jfr 11/14/2023 17:21:32'!
-sqlFreeEnv: environmentHandle 
-	"SQLRETURN SQLFreeEnv(SQLHENV EnvironmentHandle);"
-	<cdecl: int16 'SQLFreeEnv' (SQLHENV)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - environments' stamp: 'jfr 11/14/2023 17:30:57'!
-sqlSetEnvAttr: hEnv attr: attr value: value length: length 
-	"SQLRETURN SQLSetEnvAttr(
-		SQLHENV     EnvironmentHandle,
-		SQLINTEGER     Attribute,
-		SQLPOINTER     ValuePtr,
-		SQLINTEGER     StringLength);"
-	<cdecl: int16 'SQLSetEnvAttr' (SQLHENV int3264 int3264 int3264)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - environments' stamp: 'jfr 11/14/2023 17:31:04'!
-sqlSetEnvAttrPtr: hEnv attr: attr value: value length: length 
-	"SQLRETURN SQLSetEnvAttr(
-		SQLHENV     EnvironmentHandle,
-		SQLINTEGER     Attribute,
-		SQLPOINTER     ValuePtr,
-		SQLINTEGER     StringLength);"
-	<cdecl: int16 'SQLSetEnvAttr' (SQLHENV int3264 void* int3264)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:21:57'!
-sqlAllocStmtConnection: environmentHandle statement: statementHandle 
-	"SQLRETURN
-	SQLAllocStmt(
-	SQLHDBC ConnectionHandle,
-	SQLHSTMT *StatementHandle); "
-	<cdecl: int16 'SQLAllocStmt' (SQLHDBC SQLHSTMT*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:31:13'!
-sqlBindCol: statementHandle columnNumber: columnNumber targetType: targetType targetValue: targetValue bufferLength: bufferLength strLength: strLenght 
-	"SQLRETURN  
-	SQLGetData(  
-	SQLHSTMT StatementHandle,  
-	SQLUSMALLINT ColumnNumber, 
-	SQLSMALLINT TargetType,  
-	SQLPOINTER TargetValue, 
-	SQLINTEGER BufferLength,  
-	SQLINTEGER *StrLen:=or:=Ind);"
-	<cdecl: int16 'SQLBindCol' (SQLHSTMT uint16 int16 void* int3264 SQLInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:31:21'!
-sqlBindParam: statementHandle at: paramIdx appType: dtype sqlType: ptype columSize: sz digits: digits value: vptr length: lenPtr
-	"SQLRETURN  SQL_API SQLBindParam(
-		SQLHSTMT StatementHandle,
-		SQLUSMALLINT ParameterNumber, 
-		SQLSMALLINT ValueType,
-		SQLSMALLINT ParameterType, 
-		SQLULEN LengthPrecision,
-		SQLSMALLINT ParameterScale, 
-		SQLPOINTER ParameterValue,
-		SQLLEN *StrLen_or_Ind);"
-	<cdecl: int16 'SQLBindParam' (SQLHSTMT uint16 int16 int16 uint3264 int16 void* SQLInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:31:31'!
-sqlBindParameter: statementHandle at: paramIdx ioType: ioType valueType: dtype paramType: ptype columSize: sz digits: digits value: vptr bufferSize: bfsz length: lenPtr
-	"SQLRETURN SQL_API SQLBindParameter(
-		SQLHSTMT		hstmt,
-		SQLUSMALLINT	ipar,
-		SQLSMALLINT	fParamType,
-		SQLSMALLINT	fCType,
-		SQLSMALLINT	fSqlType,
-		SQLULEN		cbColDef,
-		SQLSMALLINT	ibScale,
-		SQLPOINTER	rgbValue,
-		SQLLEN			cbValueMax,
-		SQLLEN			*pcbValue);"
-	<cdecl: int16 'SQLBindParam' (SQLHSTMT uint16 int16 int16 int16 uint3264 int16 void* int3264 SQLInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:23:05'!
-sqlDescribeParam: statementHandle at: paramIdx dataType: typePtr paramSize: lengthPtr digits: scalePtr nullable: nullable
-	"SQLRETURN SQL_API SQLDescribeParam(
-		SQLHSTMT		hstmt,
-		SQLUSMALLINT	ipar,
-		SQLSMALLINT	*pfSqlType,
-		SQLULEN		*pcbParamDef,
-		SQLSMALLINT	*pibScale,
-		SQLSMALLINT	*pfNullable);"
-	<cdecl: int16 'SQLDescribeParam' (SQLHSTMT uint16 SQLSmallInteger* SQLInteger* SQLSmallInteger* SQLSmallInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:35:16'!
-sqlExecDirect: statementHandle statement: statementString length: statementLength 
-	"SQLRETURN
-	SQLExecDirect(
-	SQLHSTMT StatementHandle,
- 	SQLCHAR *StatementText,
-	SQLINTEGER TextLength);"
-	<cdecl: int16 'SQLExecDirect' (SQLHSTMT uint8* int3264)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:23:26'!
-sqlExecute: hstmt
-	"SQLRETURN SQL_API SQLExecute(
-		SQLHSTMT		hstmt);"
-	<cdecl: int16 'SQLExecute' (SQLHSTMT)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:23:33'!
-sqlFetch: statementHandle 
-	"SQLRETURN SQLFetch(SQLHSTMT StatementHandle);"
-	<cdecl: int16 'SQLFetch' (SQLHSTMT)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:23:43'!
-sqlFreeStmt: statementHandle option: optionInteger 
-	"SQLRETURN
-	SQLFreeStmt(
-	SQLHSTMT StatementHandle,
-	SQLUSMALLINT Option); "
-	<cdecl: int16 'SQLFreeStmt' (SQLHSTMT uint16)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:31:51'!
-sqlGetData: statementHandle columnNumber: columnNumber targetType: targetType targetValue: targetValue bufferLength: bufferLength strLength: strLenght 
-	"SQLRETURN 
-	SQLGetData( 
-	SQLHSTMT StatementHandle, 
-	SQLUSMALLINT ColumnNumber,
-	SQLSMALLINT TargetType, 
-	SQLPOINTER TargetValue,
-	SQLINTEGER BufferLength, 
-	SQLINTEGER *StrLen:=or:=Ind);"
-	<cdecl: int16 'SQLGetData' (SQLHSTMT uint3264 int16 void* int3264 SQLInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:24:04'!
-sqlGetTypeInfo: hstmt with: dataType
-	"SQLRETURN SQLGetTypeInfo(
-		SQLHSTMT     StatementHandle,
-		SQLSMALLINT     DataType);"
-	<cdecl: int16 'SQLGetTypeInfo' (SQLHSTMT uint16)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:24:12'!
-sqlNumParams: statementHandle into: shortArray
-	"SQLRETURN
-	SQLNumParams(
-	SQLHSTMT StatementHandle,
- 	SQLSMALLINT *pcpar);"
-	<cdecl: int16 'SQLNumParams' (SQLHSTMT SQLSmallInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:35:30'!
-sqlPrepare: statementHandle statement: statementString length: statementLength 
-	"SQLRETURN
-	SQLPrepare(
-	SQLHSTMT StatementHandle,
- 	SQLCHAR *StatementText,
-	SQLINTEGER TextLength);"
-	<cdecl: int16 'SQLPrepare' (SQLHSTMT uint8* int3264)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:32:11'!
-sqlSetStmtAttr: statementHandle name: attr value: value length: length
-	"NOTE: Use sqlSetStmtAttrPtr: if you need to pass a pointer for the value."
-	"SQLRETURN  SQL_API SQLSetStmtAttr(
-		SQLHSTMT StatementHandle,
-		SQLINTEGER Attribute, 
-		SQLPOINTER Value,
-		SQLINTEGER StringLength);"
-	<cdecl: int16 'SQLSetStmtAttr' (SQLHSTMT int3264 uint3264 int3264)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:32:19'!
-sqlSetStmtAttrPtr: statementHandle name: attr value: value length: length
-	"SQLRETURN  SQL_API SQLSetStmtAttr(
-		SQLHSTMT StatementHandle,
-		SQLINTEGER Attribute, 
-		SQLPOINTER Value,
-		SQLINTEGER StringLength);"
-	<cdecl: int16 'SQLSetStmtAttr' (SQLHSTMT int3264 void* int3264)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - statements' stamp: 'jfr 11/14/2023 17:29:57'!
-sqlSetStmtOption: statementHandle name: attr value: value
-	"SQLRETURN  SQL_API SQLSetStmtOption(
-		SQLHSTMT StatementHandle,
-		SQLUSMALLINT Option, 
-		SQLROWCOUNT Value);"
-	<cdecl: int16 'SQLSetStmtOption' (SQLHSTMT uint16 uint3264)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - resultset' stamp: 'jfr 11/14/2023 17:25:05'!
-sqlDescribeCol: statementHandle columnNumber: columnCount columnName: columnName bufferLength: bufferLength nameLength: nameLength dataType: dataType columnSize: columnSize decimalDigits: decimalDigits nullable: nullable 
-	"SQLRETURN
-	SQLDescribeCol(
-	SQLHSTMT StatementHandle, 
-	SQLUSMALLINT ColumnNumber,
-	SQLCHAR *ColumnName, 
-	SQLSMALLINT BufferLength,
-	SQLSMALLINT *NameLength, 
-	SQLSMALLINT *DataType,
-	SQLUINTEGER *ColumnSize, 
-	SQLSMALLINT *DecimalDigits,
-	SQLSMALLINT *Nullable);"
-	<cdecl: int16 'SQLDescribeCol' (SQLHSTMT uint16 void* int16 SQLSmallInteger* SQLSmallInteger* SQLUInteger* SQLSmallInteger* SQLSmallInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - resultset' stamp: 'jfr 11/14/2023 17:25:12'!
-sqlNumResultCols: statementHandle columnCount: columnCount 
-	"SQLRETURN
-	SQLNumResultCols(
-	SQLHSTMT StatementHandle,
-	SQLSMALLINT *ColumnCount); "
-	<cdecl: int16 'SQLNumResultCols' (SQLHSTMT SQLSmallInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - resultset' stamp: 'jfr 11/14/2023 17:25:19'!
-sqlRowCount: statementHandle rowCount: rowCount 
-	"SQLRETURN
-	SQLRowCount(
-	SQLHSTMT StatementHandle,
-	SQLSMALLINT *RowCount); "
-	<cdecl: int16 'SQLRowCount' (SQLHSTMT SQLSmallInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary methodsFor: 'primitives - errors' stamp: 'jfr 11/14/2023 17:25:37'!
-sqlErrorEnvironment: environmentHandle connection: connectionHandle statement: statementHandle state: stateString nativeError: nativeError messateText: messateTextString bufferLength: bufferLengthInteger textLength: textLenghtInteger 
-	"SQLRETURN
-	SQLError(
-	SQLHENV EnvironmentHandle, 
-	SQLHDBC ConnectionHandle,
-	SQLHSTMT StatementHandle, 
-	SQLCHAR *Sqlstate,
-	SQLINTEGER *NativeError, 
-	SQLCHAR *MessageText,
-	SQLSMALLINT BufferLength, 
-	SQLSMALLINT *TextLength);"
-	<cdecl: int16 'SQLError' (SQLHENV SQLHDBC SQLHSTMT void* SQLInteger* void* int16 SQLSmallInteger*)>
-	^ self externalCallFailed! !
-
-!ODBCLibrary class methodsFor: 'instance creation' stamp: 'jfr 11/14/2023 17:11:51'!
-default
-	"Answer the singleton"
-	^default ifNil:[default := super new]! !
-
-!ODBCLibrary class methodsFor: 'instance creation' stamp: 'jfr 11/14/2023 13:58:22'!
-initialize
-	"Initialize the class"
-	default := nil.! !
-
-!ODBCLibrary class methodsFor: 'instance creation' stamp: 'jfr 11/14/2023 13:49:07'!
-moduleName
-	"Return the name of the module for this library"
-	Smalltalk platformName = 'Win32' ifTrue: [ ^ 'odbc32' ].
-	Smalltalk platformName = 'unix' ifTrue: [ ^ 'libodbc.so' ].
-	Smalltalk platformName = 'Mac OS' ifTrue: [ ^ 'libodbc.dylib' ].
-	^ self error: 'Don''t know the ODBC library name'! !
-
-!ODBCLibrary class methodsFor: 'instance creation' stamp: 'jfr 11/14/2023 13:50:02'!
-new
-	^ self error:'use #default'! !
-
-!SQLByte methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLByte class>>fields."
-	<generated>
-	^handle uint8At: 1! !
-
-!SQLByte methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLByte class>>fields."
-	<generated>
-	handle uint8At: 1 put: anObject! !
-
-!SQLByte class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:07:47'!
-fields
-	" 
-	SQLByte defineFields
-	"
-	^ #(#(#value 'uint8') )! !
-
-!SQLByte class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 14:00:36'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLDate methodsFor: 'accessing'!
-day
-	"This method was automatically generated. See SQLDate class>>fields."
-	<generated>
-	^handle uint16At: 5! !
-
-!SQLDate methodsFor: 'accessing'!
-day: anObject
-	"This method was automatically generated. See SQLDate class>>fields."
-	<generated>
-	handle uint16At: 5 put: anObject! !
-
-!SQLDate methodsFor: 'accessing'!
-month
-	"This method was automatically generated. See SQLDate class>>fields."
-	<generated>
-	^handle uint16At: 3! !
-
-!SQLDate methodsFor: 'accessing'!
-month: anObject
-	"This method was automatically generated. See SQLDate class>>fields."
-	<generated>
-	handle uint16At: 3 put: anObject! !
-
-!SQLDate methodsFor: 'accessing'!
-year
-	"This method was automatically generated. See SQLDate class>>fields."
-	<generated>
-	^handle int16At: 1! !
-
-!SQLDate methodsFor: 'accessing'!
-year: anObject
-	"This method was automatically generated. See SQLDate class>>fields."
-	<generated>
-	handle int16At: 1 put: anObject! !
-
-!SQLDate class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:08:16'!
-fields
-	" 
-	SQLDate defineFields
-	"
-	^ #(#(#year 'int16') #(#month 'uint16') #(#day 'uint16') )! !
-
-!SQLDate class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 14:00:27'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLDouble methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLDouble class>>fields."
-	<generated>
-	^handle doubleAt: 1! !
-
-!SQLDouble methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLDouble class>>fields."
-	<generated>
-	handle doubleAt: 1 put: anObject! !
-
-!SQLDouble class methodsFor: 'accessing' stamp: 'dgd 5/31/2002 20:24'!
-fields
-	" 
-	SQLDouble defineFields
-	"
-	^ #(#(#value 'double') )! !
-
-!SQLDouble class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 14:00:09'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLFloat methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLFloat class>>fields."
-	<generated>
-	^handle floatAt: 1! !
-
-!SQLFloat methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLFloat class>>fields."
-	<generated>
-	handle floatAt: 1 put: anObject! !
-
-!SQLFloat class methodsFor: 'accessing' stamp: 'dgd 5/31/2002 20:23'!
-fields
-	" 
-	SQLFloat defineFields
-	"
-	^ #(#(#value 'float') )! !
-
-!SQLFloat class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 13:59:59'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLHDBC methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLHDBC class>>fields."
-	<generated>
-	^handle int64At: 1! !
-
-!SQLHDBC methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLHDBC class>>fields."
-	<generated>
-	handle int64At: 1 put: anObject! !
-
-!SQLHDBC class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:06:29'!
-fields
-	" 
-	SQLHDBC defineFields 
-	"
-	^ #(#(#value 'int3264') )! !
-
-!SQLHDBC class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:06:07'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLHENV methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLHENV class>>fields."
-	<generated>
-	^handle int64At: 1! !
-
-!SQLHENV methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLHENV class>>fields."
-	<generated>
-	handle int64At: 1 put: anObject! !
-
-!SQLHENV class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:05:33'!
-fields
-	" 
-	SQLHENV defineFields 
-	"
-	^ #(#(#value 'int3264') )! !
-
-!SQLHENV class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:05:06'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLHSTMT methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLHSTMT class>>fields."
-	<generated>
-	^handle int64At: 1! !
-
-!SQLHSTMT methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLHSTMT class>>fields."
-	<generated>
-	handle int64At: 1 put: anObject! !
-
-!SQLHSTMT class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:03:28'!
-fields
-	" 
-	SQLHSTMT defineFields
-	"
-	^ #(#(#value 'int3264') )! !
-
-!SQLHSTMT class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:04:05'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLInteger methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLInteger class>>fields."
-	<generated>
-	^handle int64At: 1! !
-
-!SQLInteger methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLInteger class>>fields."
-	<generated>
-	handle int64At: 1 put: anObject! !
-
-!SQLInteger class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:01:22'!
-fields
-	" 
-	SQLInteger defineFields 
-	"
-	^ #(#(#value 'int3264') )! !
-
-!SQLInteger class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 16:59:24'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLShort methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLShort class>>fields."
-	<generated>
-	^handle int16At: 1! !
-
-!SQLShort methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLShort class>>fields."
-	<generated>
-	handle int16At: 1 put: anObject! !
-
-!SQLShort class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:08:49'!
-fields
-	" 
-	SQLShort defineFields
-	"
-	^ #(#(#value 'int16') )! !
-
-!SQLShort class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 13:59:46'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLSmallInteger methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLSmallInteger class>>fields."
-	<generated>
-	^handle int16At: 1! !
-
-!SQLSmallInteger methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLSmallInteger class>>fields."
-	<generated>
-	handle int16At: 1 put: anObject! !
-
-!SQLSmallInteger class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:08:58'!
-fields
-	"
-	SQLSmallInteger defineFields
-	"
-	^#(
-		(value 'int16')
-	)
-! !
-
-!SQLSmallInteger class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 13:59:38'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLTime methodsFor: 'accessing'!
-hour
-	"This method was automatically generated. See SQLTime class>>fields."
-	<generated>
-	^handle uint16At: 1! !
-
-!SQLTime methodsFor: 'accessing'!
-hour: anObject
-	"This method was automatically generated. See SQLTime class>>fields."
-	<generated>
-	handle uint16At: 1 put: anObject! !
-
-!SQLTime methodsFor: 'accessing'!
-minute
-	"This method was automatically generated. See SQLTime class>>fields."
-	<generated>
-	^handle uint16At: 3! !
-
-!SQLTime methodsFor: 'accessing'!
-minute: anObject
-	"This method was automatically generated. See SQLTime class>>fields."
-	<generated>
-	handle uint16At: 3 put: anObject! !
-
-!SQLTime methodsFor: 'accessing'!
-second
-	"This method was automatically generated. See SQLTime class>>fields."
-	<generated>
-	^handle uint16At: 5! !
-
-!SQLTime methodsFor: 'accessing'!
-second: anObject
-	"This method was automatically generated. See SQLTime class>>fields."
-	<generated>
-	handle uint16At: 5 put: anObject! !
-
-!SQLTime class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:09:10'!
-fields
-	" 
-	SQLTime defineFields
-	"
-	^ #(#(#hour 'uint16') #(#minute 'uint16') #(#second 'uint16') )! !
-
-!SQLTime class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 13:59:31'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-day
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	^handle uint16At: 5! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-day: anObject
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	handle uint16At: 5 put: anObject! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-fraction
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	^handle uint32At: 13! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-fraction: anObject
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	handle uint32At: 13 put: anObject! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-hour
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	^handle uint16At: 7! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-hour: anObject
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	handle uint16At: 7 put: anObject! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-minute
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	^handle uint16At: 9! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-minute: anObject
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	handle uint16At: 9 put: anObject! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-month
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	^handle uint16At: 3! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-month: anObject
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	handle uint16At: 3 put: anObject! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-second
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	^handle uint16At: 11! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-second: anObject
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	handle uint16At: 11 put: anObject! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-year
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	^handle int16At: 1! !
-
-!SQLTimestamp methodsFor: 'accessing'!
-year: anObject
-	"This method was automatically generated. See SQLTimestamp class>>fields."
-	<generated>
-	handle int16At: 1 put: anObject! !
-
-!SQLTimestamp class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 17:09:37'!
-fields
-	" 
-	SQLTimestamp defineFields
-	"
-	^ #(#(#year 'int16') #(#month 'uint16') #(#day 'uint16') #(#hour 'uint16') #(#minute 'uint16') #(#second 'uint16') #(#fraction 'uint32') )! !
-
-!SQLTimestamp class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 13:59:22'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!SQLUInteger methodsFor: 'accessing'!
-value
-	"This method was automatically generated. See SQLUInteger class>>fields."
-	<generated>
-	^handle uint64At: 1! !
-
-!SQLUInteger methodsFor: 'accessing'!
-value: anObject
-	"This method was automatically generated. See SQLUInteger class>>fields."
-	<generated>
-	handle uint64At: 1 put: anObject! !
-
-!SQLUInteger class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 16:58:34'!
-fields
-	" 
-	SQLUInteger defineFields
-	"
-	^ #(#(#value 'uint3264') )! !
-
-!SQLUInteger class methodsFor: 'accessing' stamp: 'jfr 11/14/2023 16:57:22'!
-initialize
-	" Initialize the class "
-	self defineFields.! !
-
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:17'!
+!ODBCError methodsFor: 'initialization' stamp: 'dgd 3/Jun/2002 19:16:00'!
+initializeDetails: aCollection 
+	details := aCollection.
+""
+	self messageText: self asString! !
+
+!ODBCError methodsFor: 'printing' stamp: 'dgd 3/Jun/2002 19:17:00'!
+printOn: aStream 
+	super printOn: aStream.
+aStream nextPutAll: ' '.
+	details
+		do: [:each | aStream nextPutAll: each asString]
+		separatedBy: [aStream nextPutAll: ', ']! !
+
+!ODBCError class methodsFor: 'instance creation' stamp: 'dgd 3/Jun/2002 19:16:00'!
+details: aCollection
+	^ self new initializeDetails: aCollection! !
+
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:17:00'!
 cType
 	^cType! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:17'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:17:00'!
 cType: aNumber
 	cType := aNumber! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:17'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:17:00'!
 colWidth
 	^colWidth! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:17'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:17:00'!
 colWidth: aNumber
 	colWidth := aNumber! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:52'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:52:00'!
 data
 	^data! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:52'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:52:00'!
 data: anObject
 	data := anObject! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:18'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:18:00'!
 digits
 	^digits! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:18'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:18:00'!
 digits: aNumber
 	digits := aNumber! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:52'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:52:00'!
 handle
 	^data getHandle! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:52'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:52:00'!
 handle: aHandle
 	data := ExternalData fromHandle: aHandle type: ExternalType void asPointerType! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:18'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:18:00'!
 size
 	^size! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:18'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:18:00'!
 size: aNumber
 	size := aNumber! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:17'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:17:00'!
 sqlType
 	^sqlType! !
 
-!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 8/10/2008 17:17'!
+!ODBCBoundParameter methodsFor: 'accessing' stamp: 'ar 10/Aug/2008 17:17:00'!
 sqlType: aNumber
 	sqlType := aNumber! !
 
-!ODBCBoundParameter methodsFor: 'initialize' stamp: 'ar 8/10/2008 17:19'!
+!ODBCBoundParameter methodsFor: 'initialize' stamp: 'ar 10/Aug/2008 17:19:00'!
 initialize
 	cType := 0.
 	sqlType := 0.
@@ -1602,7 +1602,7 @@ initialize
 	digits := 0.
 	size := 0.! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'RMV 10/30/2024 20:54:58'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'RMV 30/Oct/2024 20:54:58'!
 asNumber: aString 
 	"creates a Number from aString. Could be an Integer or a Fraction"
 	| stream zero sign integerPart char fractionPart scale |
@@ -1628,12 +1628,12 @@ asNumber: aString
 	""
 	^ sign * (integerPart * scale + fractionPart / scale)! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 5/31/2002 22:06'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 31/May/2002 22:06:00'!
 booleanData
 	"answer the data for this column in the current row as a Boolean"
 ^ buffer value ~~ 0! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 5/31/2002 22:06'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 31/May/2002 22:06:00'!
 dateData
 	"answer the data for this column in the current row as a Date"
 	^ Date
@@ -1641,7 +1641,7 @@ dateData
 		month: buffer month
 		year: buffer year! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'ar 8/2/2008 14:40'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'ar 2/Aug/2008 14:40:00'!
 dateTimeData
 	"answer the data for this column in the current row as a Date/Time"
 	^TimeStamp 
@@ -1653,56 +1653,58 @@ dateTimeData
 		second: buffer second
 ! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 5/31/2002 22:05'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 31/May/2002 22:05:00'!
 doubleData
 	"answer the data for this column in the current row as an Double"
 	^ buffer value! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 5/31/2002 22:05'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 31/May/2002 22:05:00'!
 floatData
 	"answer the data for this column in the current row as an Float"
 	^ buffer value! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 5/31/2002 22:05'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 31/May/2002 22:05:00'!
 integerData
 	"answer the data for this column in the current row as an Integer"
 
 	^ buffer value! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 6/2/2002 00:59'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 2/Jun/2002 00:59:00'!
 numberData
 	"answer the data for this column in the current row as a Number"
 
 	^ self asNumber: self stringFromBuffer! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 5/31/2002 22:03'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 31/May/2002 22:03:00'!
 smallintegerData
 	"answer the data for this column in the current row as an Integer"
 	^ buffer value! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 6/2/2002 22:52'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 2/Jun/2002 22:52:00'!
 stringData
 	"answer the data for this column in the current row as a String"
 	^ self stringFromBuffer ! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'RMV 10/30/2024 20:58:05'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'OA 5/Jan/2026 21:47:20'!
 stringFromBuffer
 	"convert the buffer to a String"
 	| len result |
+	
 	len := bufferLength value min: BUFFERSIZE.
 	result := String new: len.
 	1 to: len do: [:index | 
 		result at: index put: (buffer unsignedCharAt: index)
 	].
-	^ result! !
+	
+	^CharacterSequence fromUtf8Bytes: (result asByteArray )! !
 
-!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 5/31/2002 22:03'!
+!ODBCColumn methodsFor: 'private - type convertion' stamp: 'dgd 31/May/2002 22:03:00'!
 timeData
 	"answer the data for this column in the current row as a Time"
 
 	^ Time fromSeconds: buffer hour * 3600 + (buffer minute * 60) + buffer second! !
 
-!ODBCColumn methodsFor: 'initialization' stamp: 'RMV 10/30/2024 20:57:35'!
+!ODBCColumn methodsFor: 'initialization' stamp: 'RMV 30/Oct/2024 20:57:35'!
 bindBuffer
 	"bind the column's buffer"
 	| bufferSize bufferHandle |
@@ -1729,7 +1731,7 @@ bindBuffer
 				strLength: bufferLength)
 		statement: resultSetHandle! !
 
-!ODBCColumn methodsFor: 'initialization' stamp: 'RMV 10/30/2024 20:57:53'!
+!ODBCColumn methodsFor: 'initialization' stamp: 'RMV 30/Oct/2024 20:57:53'!
 free
 	"free the associated resources"
 	bufferLength notNil
@@ -1737,7 +1739,7 @@ free
 	buffer notNil
 		ifTrue: [buffer free]! !
 
-!ODBCColumn methodsFor: 'initialization' stamp: 'dgd 6/2/2002 20:20'!
+!ODBCColumn methodsFor: 'initialization' stamp: 'dgd 2/Jun/2002 20:20:00'!
 initializeDataType: anInteger 
 	dataType := self class dataTypeNameFor: anInteger.
 	convertSelector := self class convertBufferSelectorFor: anInteger.
@@ -1745,7 +1747,7 @@ initializeDataType: anInteger
 
 	cType := self class cTypeFor: anInteger! !
 
-!ODBCColumn methodsFor: 'initialization' stamp: 'RMV 10/30/2024 20:58:00'!
+!ODBCColumn methodsFor: 'initialization' stamp: 'RMV 30/Oct/2024 20:58:00'!
 initializeResultSet: aResultSet number: anInteger 
 	"initialize the receiver"
 	| columnName nameLenght columDataType columnSize decimalDigits columnNullable |
@@ -1786,7 +1788,7 @@ initializeResultSet: aResultSet number: anInteger
 	""
 	self bindBuffer! !
 
-!ODBCColumn methodsFor: 'data' stamp: 'RMV 10/30/2024 20:57:47'!
+!ODBCColumn methodsFor: 'data' stamp: 'RMV 30/Oct/2024 20:57:47'!
 data
 	"answer the data for this column in the current row"
 "
@@ -1803,62 +1805,62 @@ data
 	^ bufferLength value == SQLNULLDATA
 		ifFalse: [self perform: convertSelector]! !
 
-!ODBCColumn methodsFor: 'accessing' stamp: 'dgd 6/2/2002 23:40'!
+!ODBCColumn methodsFor: 'accessing' stamp: 'dgd 2/Jun/2002 23:40:00'!
 decimals
 	"answer the receiver's decimals"
 	^ decimals! !
 
-!ODBCColumn methodsFor: 'accessing' stamp: 'dgd 5/27/2002 23:47'!
+!ODBCColumn methodsFor: 'accessing' stamp: 'dgd 27/May/2002 23:47:00'!
 name
 	"answer the receiver's name"
 	^ name! !
 
-!ODBCColumn methodsFor: 'accessing' stamp: 'dgd 6/2/2002 23:40'!
+!ODBCColumn methodsFor: 'accessing' stamp: 'dgd 2/Jun/2002 23:40:00'!
 nullable
 	"answer if the receiver is nullable"
 	^ nullable! !
 
-!ODBCColumn methodsFor: 'accessing' stamp: 'dgd 5/31/2002 21:37'!
+!ODBCColumn methodsFor: 'accessing' stamp: 'dgd 31/May/2002 21:37:00'!
 size
 	^ size! !
 
-!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 6/2/2002 00:57'!
+!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 2/Jun/2002 00:57:00'!
 initializeBooleanBuffer
 	buffer := SQLByte externalNew! !
 
-!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 6/2/2002 00:57'!
+!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 2/Jun/2002 00:57:00'!
 initializeDateBuffer
 	buffer := SQLDate externalNew! !
 
-!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 6/2/2002 00:57'!
+!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 2/Jun/2002 00:57:00'!
 initializeDoubleBuffer
 	buffer := SQLDouble externalNew! !
 
-!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 6/2/2002 00:57'!
+!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 2/Jun/2002 00:57:00'!
 initializeFloatBuffer
 	buffer := SQLFloat externalNew! !
 
-!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'jfr 11/13/2023 16:13:42'!
+!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'jfr 13/Nov/2023 16:13:42'!
 initializeIntegerBuffer
 	buffer := SQLInteger externalNew! !
 
-!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 6/2/2002 00:57'!
+!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 2/Jun/2002 00:57:00'!
 initializeSmallintegerBuffer
 	buffer := SQLShort externalNew! !
 
-!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 6/2/2002 20:27'!
+!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 2/Jun/2002 20:27:00'!
 initializeStringBuffer
 	buffer := ExternalAddress allocate: BUFFERSIZE! !
 
-!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 6/2/2002 00:57'!
+!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 2/Jun/2002 00:57:00'!
 initializeTimeBuffer
 	buffer := SQLTime externalNew! !
 
-!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 6/2/2002 00:57'!
+!ODBCColumn methodsFor: 'initialization - buffer' stamp: 'dgd 2/Jun/2002 00:57:00'!
 initializeTimestampBuffer
 	buffer := SQLTimestamp externalNew! !
 
-!ODBCColumn methodsFor: 'printing' stamp: 'dgd 5/27/2002 20:22'!
+!ODBCColumn methodsFor: 'printing' stamp: 'dgd 27/May/2002 20:22:00'!
 printOn: aStream 
 	super printOn: aStream.
 	aStream nextPutAll: ' ';
@@ -1876,7 +1878,7 @@ printOn: aStream
 		 nextPutAll: (nullable ifTrue:[' nullable'] ifFalse:[' not nullable']);
 		 nextPutAll: ')'! !
 
-!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 5/31/2002 21:31'!
+!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 31/May/2002 21:31:00'!
 cTypeFor: anInteger 
 	"answer the cType for anInteger"
 	DataTypes
@@ -1884,7 +1886,7 @@ cTypeFor: anInteger
 		ifPresent: [:pair | ^ pair third].
 	^ SQLCCHAR! !
 
-!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 5/31/2002 21:51'!
+!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 31/May/2002 21:51:00'!
 convertBufferSelectorFor: anInteger 
 	"answer the datatype selector for anInteger"
 	DataTypes
@@ -1892,7 +1894,7 @@ convertBufferSelectorFor: anInteger
 		ifPresent: [:pair | ^ pair second].
 	^ #stringData! !
 
-!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 5/31/2002 21:31'!
+!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 31/May/2002 21:31:00'!
 dataTypeNameFor: anInteger 
 	"answer the datatype name for anInteger"
 	DataTypes
@@ -1900,7 +1902,7 @@ dataTypeNameFor: anInteger
 		ifPresent: [:pair | ^ pair first].
 	^ #UNKOWN! !
 
-!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 6/2/2002 23:42'!
+!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 2/Jun/2002 23:42:00'!
 initializeBufferSelectorFor: anInteger 
 	"answer the initializer selector for anInteger"
 	DataTypes
@@ -1909,7 +1911,7 @@ initializeBufferSelectorFor: anInteger
 
 	^ #initializeStringBuffer! !
 
-!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 6/2/2002 22:31'!
+!ODBCColumn class methodsFor: 'data types' stamp: 'dgd 2/Jun/2002 22:31:00'!
 initializeDataTypes
 	DataTypes := Dictionary new.
 	DataTypes at: -11 put: {#GUID. #stringData. SQLCCHAR. #initializeStringBuffer};
@@ -1937,78 +1939,78 @@ initializeDataTypes
 		 at: 11 put: {#Timestamp. #dateTimeData. SQLCTIMESTAMP. #initializeTimestampBuffer};
 		 at: 12 put: {#VarChar. #stringData. SQLCCHAR. #initializeStringBuffer}! !
 
-!ODBCColumn class methodsFor: 'class initialization' stamp: 'ar 8/3/2008 14:46'!
+!ODBCColumn class methodsFor: 'class initialization' stamp: 'ar 3/Aug/2008 14:46:00'!
 initialize
 	ODBCConstants initialize. "must be initialized first"
 	self initializeDataTypes! !
 
-!ODBCColumn class methodsFor: 'instance creation' stamp: 'dgd 5/27/2002 23:47'!
+!ODBCColumn class methodsFor: 'instance creation' stamp: 'dgd 27/May/2002 23:47:00'!
 resultSet: aResultSet number: anInteger 
 	"private - creates an instance for aResultSet"
 	^ self new initializeResultSet: aResultSet number: anInteger! !
 
-!ODBCConnection methodsFor: 'private' stamp: 'dgd 5/27/2002 23:49'!
+!ODBCConnection methodsFor: 'private' stamp: 'dgd 27/May/2002 23:49:00'!
 addStatement: aStatement 
 	"private - add aStatement to the statements collection"
 	^ statements add: aStatement! !
 
-!ODBCConnection methodsFor: 'private' stamp: 'dgd 5/27/2002 23:14'!
+!ODBCConnection methodsFor: 'private' stamp: 'dgd 27/May/2002 23:14:00'!
 checkConnected
 	"private - check if the recevier is connected"
 	self isConnected
 		ifFalse: [^ self error: 'unconnected!!']! !
 
-!ODBCConnection methodsFor: 'private' stamp: 'dgd 5/27/2002 23:14'!
+!ODBCConnection methodsFor: 'private' stamp: 'dgd 27/May/2002 23:14:00'!
 checkNotConnected
 	"private - check if the recevier is not connected"
 	self isConnected
 		ifTrue: [^ self error: 'connected!!']! !
 
-!ODBCConnection methodsFor: 'private' stamp: 'ar 8/10/2008 11:47'!
+!ODBCConnection methodsFor: 'private' stamp: 'ar 10/Aug/2008 11:47:00'!
 handle
 	"private - answer the receiver's handle"
 	^ hdbc! !
 
-!ODBCConnection methodsFor: 'private' stamp: 'dgd 6/2/2002 23:42'!
+!ODBCConnection methodsFor: 'private' stamp: 'dgd 2/Jun/2002 23:42:00'!
 log: anObject 
 	"private - log a message"
 	self class log: anObject! !
 
-!ODBCConnection methodsFor: 'accessing' stamp: 'ar 8/2/2008 15:13'!
+!ODBCConnection methodsFor: 'accessing' stamp: 'ar 2/Aug/2008 15:13:00'!
 asyncStatements
 	"Indicates whether the connection should use async statements or not"
 	^asyncStatements! !
 
-!ODBCConnection methodsFor: 'accessing' stamp: 'ar 8/2/2008 15:13'!
+!ODBCConnection methodsFor: 'accessing' stamp: 'ar 2/Aug/2008 15:13:00'!
 asyncStatements: aBool
 	"Indicates whether the connection should use async statements or not"
 	asyncStatements := aBool! !
 
-!ODBCConnection methodsFor: 'accessing' stamp: 'dgd 5/27/2002 23:47'!
+!ODBCConnection methodsFor: 'accessing' stamp: 'dgd 27/May/2002 23:47:00'!
 dsn: dsnString 
 	"change the receiver's dsn"
 	self checkNotConnected.
 	dsn := dsnString! !
 
-!ODBCConnection methodsFor: 'accessing' stamp: 'dgd 5/27/2002 23:48'!
+!ODBCConnection methodsFor: 'accessing' stamp: 'dgd 27/May/2002 23:48:00'!
 password: passwordString 
 	"change the receiver's password"
 	self checkNotConnected.
 	password := passwordString! !
 
-!ODBCConnection methodsFor: 'accessing' stamp: 'dgd 5/27/2002 23:48'!
+!ODBCConnection methodsFor: 'accessing' stamp: 'dgd 27/May/2002 23:48:00'!
 user: userString 
 	"change the receiver's user"
 	self checkNotConnected.
 	user := userString! !
 
-!ODBCConnection methodsFor: 'transactions' stamp: 'ar 8/10/2008 12:11'!
+!ODBCConnection methodsFor: 'transactions' stamp: 'ar 10/Aug/2008 12:11:00'!
 autoCommit
 	"answer if the receiver is in autoCommit mode"
 	self checkConnected.
 	^ (self sqlGetConnectAttr: SQLATTRAUTOCOMMIT) = SQLAUTOCOMMITON! !
 
-!ODBCConnection methodsFor: 'transactions' stamp: 'ar 8/10/2008 12:11'!
+!ODBCConnection methodsFor: 'transactions' stamp: 'ar 10/Aug/2008 12:11:00'!
 autoCommit: aBoolean 
 	"setthe receiver's auto commit option"
 	self checkConnected.
@@ -2017,7 +2019,7 @@ autoCommit: aBoolean
 				ifTrue: [SQLAUTOCOMMITON]
 				ifFalse: [SQLAUTOCOMMITOFF])! !
 
-!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 6/3/2002 22:48'!
+!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 3/Jun/2002 22:48:00'!
 beginTransaction
 	"create a transaction.  set the auto commit option on if necessary"
 	self checkConnected.
@@ -2026,13 +2028,13 @@ beginTransaction
 	openTransaction := true.
 	self ensureAutoCommitOff! !
 
-!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 6/3/2002 21:47'!
+!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 3/Jun/2002 21:47:00'!
 commitTransaction
 	"commit the open transaction"
 	self endTransactionCompletion:  SQLCOMMIT
 ! !
 
-!ODBCConnection methodsFor: 'transactions' stamp: 'jfr 11/13/2023 16:03:11'!
+!ODBCConnection methodsFor: 'transactions' stamp: 'jfr 13/Nov/2023 16:03:11'!
 endTransactionCompletion: anInteger 
 	"private - close the transaction with completion ROOLBACK o COMMIT"
 	self checkConnected.
@@ -2045,18 +2047,18 @@ endTransactionCompletion: anInteger
 				completionType: anInteger).
 openTransaction := false.! !
 
-!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 6/3/2002 22:20'!
+!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 3/Jun/2002 22:20:00'!
 ensureAutoCommitOff
 	"ensure auto commit false"
 	self autoCommit
 		ifTrue: [self autoCommit: false]! !
 
-!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 6/3/2002 21:47'!
+!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 3/Jun/2002 21:47:00'!
 rollbackTransaction
 	"rollback the open transaction"
 	self endTransactionCompletion: SQLROLLBACK! !
 
-!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 6/3/2002 22:43'!
+!ODBCConnection methodsFor: 'transactions' stamp: 'dgd 3/Jun/2002 22:43:00'!
 transactionDuring: aBlock 
 	"evaluate aBlock in a transaction  
 	 
@@ -2075,7 +2077,7 @@ transactionDuring: aBlock
 			self rollbackTransaction.
 			lastError signal]! !
 
-!ODBCConnection methodsFor: 'connecting' stamp: 'ar 8/10/2008 12:18'!
+!ODBCConnection methodsFor: 'connecting' stamp: 'ar 10/Aug/2008 12:18:00'!
 checkFeatures
 	"Check for the available features of the driver"
 	| resp |
@@ -2092,7 +2094,7 @@ checkFeatures
 	features at: #searchEscape put: resp.
 ! !
 
-!ODBCConnection methodsFor: 'connecting' stamp: 'ar 8/10/2008 11:46'!
+!ODBCConnection methodsFor: 'connecting' stamp: 'ar 10/Aug/2008 11:46:00'!
 close
 	"close the receiver and all the childrents"
 	self isConnected ifFalse: [
@@ -2110,7 +2112,7 @@ close
 	self unregisterForFinalization.
 	connected := false.! !
 
-!ODBCConnection methodsFor: 'connecting' stamp: 'jfr 11/13/2023 16:03:06'!
+!ODBCConnection methodsFor: 'connecting' stamp: 'jfr 13/Nov/2023 16:03:06'!
 closeNotFail
 	"close the receiver without signaling errors"
 	self isConnected
@@ -2127,7 +2129,7 @@ closeNotFail
 	self unregisterForFinalization.
 ! !
 
-!ODBCConnection methodsFor: 'connecting' stamp: 'jfr 11/13/2023 12:14:29'!
+!ODBCConnection methodsFor: 'connecting' stamp: 'jfr 13/Nov/2023 12:14:29'!
 connect
 	"Connect to the database"
 	self registerForFinalization.
@@ -2153,14 +2155,14 @@ connect
 	self checkFeatures.
 	connected := true! !
 
-!ODBCConnection methodsFor: 'connecting' stamp: 'ar 8/13/2008 12:41'!
+!ODBCConnection methodsFor: 'connecting' stamp: 'ar 13/Aug/2008 12:41:00'!
 driverString
 	"Answers the driver string for a dsn-less connection"
 	^String streamContents:[:s |
 		s nextPutAll: dsn; nextPutAll: ';UID='; nextPutAll: user; nextPutAll: ';PWD='; nextPutAll: password
 	].! !
 
-!ODBCConnection methodsFor: 'connecting' stamp: 'ar 8/10/2008 11:48'!
+!ODBCConnection methodsFor: 'connecting' stamp: 'ar 10/Aug/2008 11:48:00'!
 open
 	"open the connection"
 	self isConnected ifTrue: [
@@ -2168,7 +2170,7 @@ open
 		^ self].
 	self connect.! !
 
-!ODBCConnection methodsFor: 'private - errors' stamp: 'ar 8/10/2008 11:46'!
+!ODBCConnection methodsFor: 'private - errors' stamp: 'ar 10/Aug/2008 11:46:00'!
 checkSQLReturn: sqlReturn 
 	"private - check the sqlReturn and generates an exception if corresponds"
 	self
@@ -2177,7 +2179,7 @@ checkSQLReturn: sqlReturn
 		connection: hdbc
 		statement: nil! !
 
-!ODBCConnection methodsFor: 'private - errors' stamp: 'dgd 5/30/2002 00:19'!
+!ODBCConnection methodsFor: 'private - errors' stamp: 'dgd 30/May/2002 00:19:00'!
 checkSQLReturn: sqlReturn environment: anEnvironmentHandle connection: aConnectionHandle statement: aStatementHandle 
 	"private - check the sqlReturn and generates an exception if corresponds"
 	sqlReturn == SQLSUCCESS
@@ -2188,7 +2190,7 @@ checkSQLReturn: sqlReturn environment: anEnvironmentHandle connection: aConnecti
 				connection: aConnectionHandle
 				statement: aStatementHandle]! !
 
-!ODBCConnection methodsFor: 'private - errors' stamp: 'ar 8/10/2008 11:46'!
+!ODBCConnection methodsFor: 'private - errors' stamp: 'ar 10/Aug/2008 11:46:00'!
 checkSQLReturn: sqlReturn statement: aStatementHandle
 	"private - check the sqlReturn and generates an exception if corresponds"
 	self
@@ -2197,7 +2199,7 @@ checkSQLReturn: sqlReturn statement: aStatementHandle
 		connection: hdbc
 		statement: aStatementHandle! !
 
-!ODBCConnection methodsFor: 'private - errors' stamp: 'jfr 11/13/2023 16:09:51'!
+!ODBCConnection methodsFor: 'private - errors' stamp: 'jfr 13/Nov/2023 16:09:51'!
 getErrorSQLReturn: sqlReturn environment: anEnvironmentHandle connection: aConnectionHandle statement: aStatementHandle 
 	"private - check the sqlReturn and generates an exception if corresponds"
 	| stateString nativeError messateTextString textLenght envHandle conHandle staHandle details exception |
@@ -2238,12 +2240,12 @@ getErrorSQLReturn: sqlReturn environment: anEnvironmentHandle connection: aConne
 	self log: exception.
 	exception signal! !
 
-!ODBCConnection methodsFor: 'statements' stamp: 'ar 8/10/2008 16:49'!
+!ODBCConnection methodsFor: 'statements' stamp: 'ar 10/Aug/2008 16:49:00'!
 execute: queryString
 	"Execute the given query without any arguments"
 	^self execute: queryString args: #()! !
 
-!ODBCConnection methodsFor: 'statements' stamp: 'ar 8/10/2008 16:49'!
+!ODBCConnection methodsFor: 'statements' stamp: 'ar 10/Aug/2008 16:49:00'!
 execute: queryString args: args
 	"Execute the given query with the provided arguments"
 	| stmt result |
@@ -2251,24 +2253,24 @@ execute: queryString args: args
 	result := stmt execute: args.
 	^result! !
 
-!ODBCConnection methodsFor: 'statements' stamp: 'ar 8/3/2008 12:44'!
+!ODBCConnection methodsFor: 'statements' stamp: 'ar 3/Aug/2008 12:44:00'!
 newPreparedStatement
 	"Answer a new prepared statement without any associated query"
 	^ODBCPreparedStatement connection: self query: nil.! !
 
-!ODBCConnection methodsFor: 'statements' stamp: 'ar 8/2/2008 13:18'!
+!ODBCConnection methodsFor: 'statements' stamp: 'ar 2/Aug/2008 13:18:00'!
 prepare: aString 
 	"creates a new prepared statement for queryString"
 	self checkConnected.
 	^ ODBCPreparedStatement connection: self query: aString! !
 
-!ODBCConnection methodsFor: 'statements' stamp: 'dgd 6/3/2002 21:36'!
+!ODBCConnection methodsFor: 'statements' stamp: 'dgd 3/Jun/2002 21:36:00'!
 query: aString 
 	"creates a new statement for queryString"
 	self checkConnected.
 	^ ODBCStatement connection: self query: aString! !
 
-!ODBCConnection methodsFor: 'statements' stamp: 'rjl 9/4/2008 16:02'!
+!ODBCConnection methodsFor: 'statements' stamp: 'rjl 4/Sep/2008 16:02:00'!
 resultSetFor: aString 
 	| secondTry |
 	secondTry := false.
@@ -2284,27 +2286,27 @@ resultSetFor: aString
 			secondTry := true.
 			err retry ]! !
 
-!ODBCConnection methodsFor: 'statements' stamp: 'rjl 9/4/2008 16:03'!
+!ODBCConnection methodsFor: 'statements' stamp: 'rjl 4/Sep/2008 16:03:00'!
 run: aString 
 	^ (self resultSetFor: aString) asTable! !
 
-!ODBCConnection methodsFor: 'private - finalization' stamp: 'dgd 5/27/2002 20:55'!
+!ODBCConnection methodsFor: 'private - finalization' stamp: 'dgd 27/May/2002 20:55:00'!
 finalize
 	self closeNotFail! !
 
-!ODBCConnection methodsFor: 'private - finalization' stamp: 'dgd 5/26/2002 19:18'!
+!ODBCConnection methodsFor: 'private - finalization' stamp: 'dgd 26/May/2002 19:18:00'!
 registerForFinalization
 	"private - register the receiver to the class side registry for finalization  
 	notification"
 	self class register: self! !
 
-!ODBCConnection methodsFor: 'private - finalization' stamp: 'dgd 5/26/2002 19:18'!
+!ODBCConnection methodsFor: 'private - finalization' stamp: 'dgd 26/May/2002 19:18:00'!
 unregisterForFinalization
 	"private - unregister the receiver to the class side registry for 
 	finalization notification"
 	self class unregister: self! !
 
-!ODBCConnection methodsFor: 'initialization' stamp: 'ar 8/2/2008 15:13'!
+!ODBCConnection methodsFor: 'initialization' stamp: 'ar 2/Aug/2008 15:13:00'!
 initialize
 	"initialize the receiver"
 	connected := false.
@@ -2315,19 +2317,19 @@ initialize
 	openTransaction := false.
 	asyncStatements := false.! !
 
-!ODBCConnection methodsFor: 'initialization' stamp: 'dgd 5/30/2002 23:29'!
+!ODBCConnection methodsFor: 'initialization' stamp: 'dgd 30/May/2002 23:29:00'!
 initializeDsn: dsnString user: userString password: passwordString 
 	"initialize the receiver"
 	dsn := dsnString.
 	user := userString.
 	password := passwordString! !
 
-!ODBCConnection methodsFor: 'query' stamp: 'dgd 5/26/2002 19:16'!
+!ODBCConnection methodsFor: 'query' stamp: 'dgd 26/May/2002 19:16:00'!
 isConnected
 	"answer if the receiver is connected"
 	^ connected! !
 
-!ODBCConnection methodsFor: 'printing' stamp: 'dgd 6/3/2002 22:15'!
+!ODBCConnection methodsFor: 'printing' stamp: 'dgd 3/Jun/2002 22:15:00'!
 printOn: aStream 
 	super printOn: aStream.
 	aStream nextPutAll: ', dsn:';
@@ -2346,17 +2348,17 @@ printOn: aStream
 				ifFalse: [' (open transaction)']).
 	 ! !
 
-!ODBCConnection methodsFor: 'snapshots' stamp: 'dgd 5/27/2002 23:08'!
+!ODBCConnection methodsFor: 'snapshots' stamp: 'dgd 27/May/2002 23:08:00'!
 shutDown
 	self isConnected
 		ifTrue: [self closeNotFail]! !
 
-!ODBCConnection methodsFor: 'snapshots' stamp: 'ar 8/10/2008 11:48'!
+!ODBCConnection methodsFor: 'snapshots' stamp: 'ar 10/Aug/2008 11:48:00'!
 startUp
 	self isConnected
 		ifTrue: [self connect]! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:09:59'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:09:59'!
 sqlAllocConnect: envHandle
 	| h |
 	h := SQLHDBC new.
@@ -2366,14 +2368,14 @@ sqlAllocConnect: envHandle
 	^h
 ! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:12:59'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:12:59'!
 sqlAllocEnv
 	| h |
 	h := SQLHENV new.
 	self checkSQLReturn: (ODBCLibrary default sqlAllocEnv: h).
 	^h! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:03:51'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:03:51'!
 sqlConnect: dsnString user: userString password: passString
 	self checkSQLReturn: (ODBCLibrary default
 				sqlConnect: hdbc
@@ -2385,11 +2387,11 @@ sqlConnect: dsnString user: userString password: passString
 				authenticationLength: passString size).
 ! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:03:56'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:03:56'!
 sqlDisconnect: h
 	self checkSQLReturn: (ODBCLibrary default sqlDisconnect: h).! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:04:03'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:04:03'!
 sqlDriverConnect: connString completion: flags
 	| outString outStringSizePtr |
 	outString := String new: 1024 withAll: $ .
@@ -2399,17 +2401,17 @@ sqlDriverConnect: connString completion: flags
 	).
 	^outString copyFrom: 1 to: outStringSizePtr value! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:04:07'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:04:07'!
 sqlFreeConnect: h
 	self checkSQLReturn: (ODBCLibrary default sqlFreeConnect: h).
 ! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:04:12'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:04:12'!
 sqlFreeEnv: h
 	self checkSQLReturn: (ODBCLibrary default sqlFreeEnv: h).
 ! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:14:01'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:14:01'!
 sqlGetConnectAttr: key 
 	"answer an long attribute of the receiver"
 	| buffer |
@@ -2420,7 +2422,7 @@ sqlGetConnectAttr: key
 			length: SQLUINTEGER valueLength: nil).
 	^ buffer value! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:04:22'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:04:22'!
 sqlGetInfoString: infoType
 	| buffer length |
 	buffer := String new: 255.
@@ -2430,7 +2432,7 @@ sqlGetInfoString: infoType
 	).
 	^buffer copyFrom: 1 to: 1 + length value! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:04:28'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:04:28'!
 sqlSetConnectAttr: key value: value 
 	"change a long attribute of the receiver"
 	self checkConnected.
@@ -2438,13 +2440,13 @@ sqlSetConnectAttr: key value: value
 		sqlSetConnectAttr: hdbc attribute: key value: value length: SQLUINTEGER
 	)! !
 
-!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:04:33'!
+!ODBCConnection methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:04:33'!
 sqlSetEnvAttr: attr value: value
 	self checkSQLReturn: (ODBCLibrary default 
 		sqlSetEnvAttr: hEnv attr: attr value: value length: 0
 	)! !
 
-!ODBCConnection class methodsFor: 'housekeeping' stamp: 'dgd 6/3/2002 19:00'!
+!ODBCConnection class methodsFor: 'housekeeping' stamp: 'dgd 3/Jun/2002 19:00:00'!
 cleanAll
 	"try to clean all connections"
 	self log: 'clossing all connections'.
@@ -2456,14 +2458,14 @@ cleanAll
 	""
 	self log: self name , ' ' , ODBCConnection allInstances size asString , ' instances alive!!'! !
 
-!ODBCConnection class methodsFor: 'housekeeping' stamp: 'dgd 6/3/2002 18:56'!
+!ODBCConnection class methodsFor: 'housekeeping' stamp: 'dgd 3/Jun/2002 18:56:00'!
 closeAll
 	"close all open connections"
 	ODBCConnection allInstances
 		do: [:each | each close].
 self registry finalizeValues! !
 
-!ODBCConnection class methodsFor: 'instance creation' stamp: 'rjl 9/4/2008 15:33'!
+!ODBCConnection class methodsFor: 'instance creation' stamp: 'rjl 4/Sep/2008 15:33:00'!
 dsn: dsnString user: userString password: passwordString 
 	"creates a new instance of the receiver and open the connection"
 	| instance |
@@ -2474,13 +2476,13 @@ dsn: dsnString user: userString password: passwordString
 	[instance open] on: ODBCWarning do: [:e | e resume ].
 	^ instance! !
 
-!ODBCConnection class methodsFor: 'instance creation' stamp: 'dgd 5/27/2002 23:07'!
+!ODBCConnection class methodsFor: 'instance creation' stamp: 'dgd 27/May/2002 23:07:00'!
 new
 	"creates a new instance of the receiver"
 
 	^ super new initialize.! !
 
-!ODBCConnection class methodsFor: 'instance creation' stamp: 'ar 8/13/2008 12:31'!
+!ODBCConnection class methodsFor: 'instance creation' stamp: 'ar 13/Aug/2008 12:31:00'!
 toSqlServer: serverString database: dbString applicationId: appString workstationId: wsidString user: userString password: passwordString
 
 	| connectString |
@@ -2493,7 +2495,7 @@ toSqlServer: serverString database: dbString applicationId: appString workstatio
 
 ! !
 
-!ODBCConnection class methodsFor: 'instance creation' stamp: 'jrp 9/15/2004 22:44'!
+!ODBCConnection class methodsFor: 'instance creation' stamp: 'jrp 15/Sep/2004 22:44:00'!
 toSqlServer: serverString database: dbString user: userString password: passwordString
 
 	^ self
@@ -2506,12 +2508,12 @@ toSqlServer: serverString database: dbString user: userString password: password
 
 ! !
 
-!ODBCConnection class methodsFor: 'instance creation' stamp: 'jrp 9/15/2004 22:44'!
+!ODBCConnection class methodsFor: 'instance creation' stamp: 'jrp 15/Sep/2004 22:44:00'!
 workstationId
 
 	^ Utilities authorNamePerSe, '@', NetNameResolver localHostName! !
 
-!ODBCConnection class methodsFor: 'samples' stamp: 'ar 8/2/2008 13:56'!
+!ODBCConnection class methodsFor: 'samples' stamp: 'ar 2/Aug/2008 13:56:00'!
 dsn: dsnString user: userString password: passwordString query: queryString 
 	"execute a query and show some statistics information"
 	| connection statement resultSet columns rowCount iterationTime timePerRow |
@@ -2542,7 +2544,7 @@ dsn: dsnString user: userString password: passwordString query: queryString
 	self log: 'Iterating ResulSet has ' , rowCount asString , ' rows and was iterated in ' , iterationTime asString , 'ms  (' , timePerRow asString , 'ms/row)'.
 	connection close! !
 
-!ODBCConnection class methodsFor: 'samples' stamp: 'dgd 6/2/2002 23:42'!
+!ODBCConnection class methodsFor: 'samples' stamp: 'dgd 2/Jun/2002 23:42:00'!
 log: anObject 
 	"private - log a message"
 	| logMessage |
@@ -2555,39 +2557,39 @@ log: anObject
 	Transcript show: logMessage contents;
 		 cr! !
 
-!ODBCConnection class methodsFor: 'class initialization' stamp: 'dgd 5/27/2002 21:16'!
+!ODBCConnection class methodsFor: 'class initialization' stamp: 'dgd 27/May/2002 21:16:00'!
 initialize
 	Smalltalk addToStartUpList: self.
 	Smalltalk addToShutDownList: self! !
 
-!ODBCConnection class methodsFor: 'registry' stamp: 'dgd 5/26/2002 18:25'!
+!ODBCConnection class methodsFor: 'registry' stamp: 'dgd 26/May/2002 18:25:00'!
 register: anObject 
 	self registry add: anObject! !
 
-!ODBCConnection class methodsFor: 'registry' stamp: 'jmv 1/17/2025 11:47:21'!
+!ODBCConnection class methodsFor: 'registry' stamp: 'jmv 17/Jan/2025 11:47:21'!
 registry
 	^ Registry ifNil: [Registry := FinalizationRegistry new]
 ! !
 
-!ODBCConnection class methodsFor: 'registry' stamp: 'dgd 5/26/2002 18:25'!
+!ODBCConnection class methodsFor: 'registry' stamp: 'dgd 26/May/2002 18:25:00'!
 unregister: anObject 
 	self registry
 		remove: anObject
 		ifAbsent: []! !
 
-!ODBCConnection class methodsFor: 'snapshots' stamp: 'dgd 5/27/2002 23:07'!
+!ODBCConnection class methodsFor: 'snapshots' stamp: 'dgd 27/May/2002 23:07:00'!
 shutDown
 	super shutDown.
 	self allSubInstances
 		do: [:each | each shutDown]! !
 
-!ODBCConnection class methodsFor: 'snapshots' stamp: 'dgd 5/27/2002 23:07'!
+!ODBCConnection class methodsFor: 'snapshots' stamp: 'dgd 27/May/2002 23:07:00'!
 startUp
 	super startUp.
 	self allSubInstances
 		do: [:each | each startUp]! !
 
-!ODBCErrorDetail methodsFor: 'initialization' stamp: 'dgd 6/3/2002 19:12'!
+!ODBCErrorDetail methodsFor: 'initialization' stamp: 'dgd 3/Jun/2002 19:12:00'!
 initializeState: stateString message: messageString nativeError: nativeErrorNumber 
 	"initialize the receiver"
 	state := stateString.
@@ -2595,7 +2597,7 @@ initializeState: stateString message: messageString nativeError: nativeErrorNumb
 	nativeError := nativeErrorNumber.
 ! !
 
-!ODBCErrorDetail methodsFor: 'printing' stamp: 'dgd 6/3/2002 19:13'!
+!ODBCErrorDetail methodsFor: 'printing' stamp: 'dgd 3/Jun/2002 19:13:00'!
 printOn: aStream 
 	aStream nextPutAll: '[State:';
 		 nextPutAll: state asString;
@@ -2604,72 +2606,72 @@ printOn: aStream
 		 nextPutAll: '] Error:';
 		 nextPutAll: message asString! !
 
-!ODBCErrorDetail class methodsFor: 'instance creation' stamp: 'dgd 6/3/2002 19:13'!
+!ODBCErrorDetail class methodsFor: 'instance creation' stamp: 'dgd 3/Jun/2002 19:13:00'!
 state: stateString message: messageString nativeError: nativeErrorNumber 
 	^ self new
 		initializeState: stateString
 		message: messageString
 		nativeError: nativeErrorNumber! !
 
-!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 8/4/2008 16:09'!
+!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 4/Aug/2008 16:09:00'!
 dataType
 	"The SQL data type associated with the parameter"
 	^dataType! !
 
-!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 8/4/2008 16:10'!
+!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 4/Aug/2008 16:10:00'!
 dataType: anInteger
 	"The SQL data type associated with the parameter"
 	dataType := anInteger! !
 
-!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 8/4/2008 16:10'!
+!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 4/Aug/2008 16:10:00'!
 digits
 	"The number of relevant digits for the parameter"
 	^digits! !
 
-!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 8/4/2008 16:10'!
+!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 4/Aug/2008 16:10:00'!
 digits: anInteger
 	"The number of relevant digits for the parameter"
 	digits := anInteger! !
 
-!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 8/4/2008 16:11'!
+!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 4/Aug/2008 16:11:00'!
 nullable
 	"Whether the parameter can be NULL"
 	^nullable! !
 
-!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 8/4/2008 16:11'!
+!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 4/Aug/2008 16:11:00'!
 nullable: aBool
 	"Whether the parameter can be NULL"
 	nullable := aBool! !
 
-!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 8/4/2008 16:10'!
+!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 4/Aug/2008 16:10:00'!
 paramSize
 	"The size of the parameter"
 	^paramSize! !
 
-!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 8/4/2008 16:10'!
+!ODBCParamDescription methodsFor: 'accessing' stamp: 'ar 4/Aug/2008 16:10:00'!
 paramSize: anInteger
 	"The size of the parameter"
 	paramSize := anInteger! !
 
-!ODBCStatement methodsFor: 'private' stamp: 'dgd 5/27/2002 23:52'!
+!ODBCStatement methodsFor: 'private' stamp: 'dgd 27/May/2002 23:52:00'!
 addResulSet: aResulSet 
 	"private - add aResultSet to the resultSets collection"
 	^ resultSets add: aResulSet! !
 
-!ODBCStatement methodsFor: 'private' stamp: 'dgd 5/27/2002 23:17'!
+!ODBCStatement methodsFor: 'private' stamp: 'dgd 27/May/2002 23:17:00'!
 checkConnected
 	"private - check if the recevier is connected"
 	self isConnected
 		ifFalse: [^ self error: 'unconnected!!']! !
 
-!ODBCStatement methodsFor: 'private' stamp: 'ar 8/10/2008 19:59'!
+!ODBCStatement methodsFor: 'private' stamp: 'ar 10/Aug/2008 19:59:00'!
 freeArgBuffers
 	"Free the allocate buffers"
 	argBuffers ifNil:[^self].
 	argBuffers do:[:each| each ifNotNil:[each data free]].
 	argBuffers := nil.! !
 
-!ODBCStatement methodsFor: 'executing' stamp: 'ar 8/10/2008 19:59'!
+!ODBCStatement methodsFor: 'executing' stamp: 'ar 10/Aug/2008 19:59:00'!
 bind: arguments
 	"Bind the statement with the given args."
 	| arg buf |
@@ -2688,7 +2690,7 @@ bind: arguments
 	].
 ! !
 
-!ODBCStatement methodsFor: 'executing' stamp: 'fgz 7/2/2024 09:36:04'!
+!ODBCStatement methodsFor: 'executing' stamp: 'fgz 2/Jul/2024 09:36:04'!
 bindArg: arg
 	"Bind the argument at the given position"
 	| buf sz |
@@ -2750,20 +2752,22 @@ bindArg: arg
 
 	^self error: 'Cannot bind argument'! !
 
-!ODBCStatement methodsFor: 'executing' stamp: 'ar 8/10/2008 16:51'!
+!ODBCStatement methodsFor: 'executing' stamp: 'ar 10/Aug/2008 16:51:00'!
 execute
 	"Execute the query and answer the result"
 	^self execute: #()! !
 
-!ODBCStatement methodsFor: 'executing' stamp: 'ar 8/10/2008 18:00'!
+!ODBCStatement methodsFor: 'executing' stamp: 'OA 9/Jan/2026 22:32:15'!
 execute: args
 	"Execute the query with the given arguments and answer the result"
+	
 	self checkConnected.
 	self bind: args.
-	self sqlExecDirect: query.
+	self sqlExecDirect: query asByteArray asString.
+	
 	^ODBCResultSet connection: connection statement: self! !
 
-!ODBCStatement methodsFor: 'executing' stamp: 'fgz 7/2/2024 09:36:14'!
+!ODBCStatement methodsFor: 'executing' stamp: 'fgz 2/Jul/2024 09:36:14'!
 fillArg: buf with: arg
 	"Fill a bound parameter with a new value. Answer true if successful, false otherwise"
 	| argHandle |
@@ -2817,60 +2821,60 @@ fillArg: buf with: arg
 	} otherwise:[^false].
 ! !
 
-!ODBCStatement methodsFor: 'executing' stamp: 'ar 8/10/2008 16:18'!
+!ODBCStatement methodsFor: 'executing' stamp: 'ar 10/Aug/2008 16:18:00'!
 getTypeInfo
 	^self getTypeInfo: 0 "SQL_ALL_TYPES"! !
 
-!ODBCStatement methodsFor: 'executing' stamp: 'ar 8/10/2008 16:18'!
+!ODBCStatement methodsFor: 'executing' stamp: 'ar 10/Aug/2008 16:18:00'!
 getTypeInfo: dataType
 	self sqlGetTypeInfo: dataType.
 	^ODBCResultSet connection: connection statement: self! !
 
-!ODBCStatement methodsFor: 'connecting' stamp: 'ar 8/10/2008 19:57'!
+!ODBCStatement methodsFor: 'connecting' stamp: 'ar 10/Aug/2008 19:57:00'!
 close
 	"close the receiver and all the childrents"
 	self freeArgBuffers.
 	resultSets do: [:each | each close].
 	self unregisterForFinalization! !
 
-!ODBCStatement methodsFor: 'connecting' stamp: 'ar 8/10/2008 19:57'!
+!ODBCStatement methodsFor: 'connecting' stamp: 'ar 10/Aug/2008 19:57:00'!
 closeNotFail
 	"close the receiver without signaling errors"
 	self freeArgBuffers.
 	resultSets do: [:each | each closeNotFail].
 	self unregisterForFinalization! !
 
-!ODBCStatement methodsFor: 'private - finalization' stamp: 'dgd 5/27/2002 21:24'!
+!ODBCStatement methodsFor: 'private - finalization' stamp: 'dgd 27/May/2002 21:24:00'!
 finalize
 	self closeNotFail! !
 
-!ODBCStatement methodsFor: 'private - finalization' stamp: 'dgd 5/26/2002 22:45'!
+!ODBCStatement methodsFor: 'private - finalization' stamp: 'dgd 26/May/2002 22:45:00'!
 registerForFinalization
 	"private - register the receiver to the class side registry for finalization  
 	notification"
 	connection class register: self! !
 
-!ODBCStatement methodsFor: 'private - finalization' stamp: 'dgd 5/26/2002 22:45'!
+!ODBCStatement methodsFor: 'private - finalization' stamp: 'dgd 26/May/2002 22:45:00'!
 unregisterForFinalization
 	"private - unregister the receiver to the class side registry for  
 	finalization notification"
 	connection class unregister: self! !
 
-!ODBCStatement methodsFor: 'accessing' stamp: 'ar 8/2/2008 13:58'!
+!ODBCStatement methodsFor: 'accessing' stamp: 'ar 2/Aug/2008 13:58:00'!
 handle
 	"answer the receiver's handle"
 	^ handle! !
 
-!ODBCStatement methodsFor: 'accessing' stamp: 'dgd 5/27/2002 23:51'!
+!ODBCStatement methodsFor: 'accessing' stamp: 'dgd 27/May/2002 23:51:00'!
 query
 	"answer the receiver's query"
 	^ query! !
 
-!ODBCStatement methodsFor: 'accessing' stamp: 'ar 8/3/2008 13:39'!
+!ODBCStatement methodsFor: 'accessing' stamp: 'ar 3/Aug/2008 13:39:00'!
 query: queryString
 	query := queryString! !
 
-!ODBCStatement methodsFor: 'initialization' stamp: 'ar 8/10/2008 18:00'!
+!ODBCStatement methodsFor: 'initialization' stamp: 'ar 10/Aug/2008 18:00:00'!
 initializeConnection: aConnection query: aString 
 	"initialize the receiver"
 	resultSets := WeakSet new.
@@ -2885,12 +2889,12 @@ initializeConnection: aConnection query: aString
 	].
 ! !
 
-!ODBCStatement methodsFor: 'query' stamp: 'dgd 5/27/2002 23:16'!
+!ODBCStatement methodsFor: 'query' stamp: 'dgd 27/May/2002 23:16:00'!
 isConnected
 	"answer if the receiver is connected"
 	^ connection isConnected! !
 
-!ODBCStatement methodsFor: 'printing' stamp: 'dgd 5/27/2002 23:19'!
+!ODBCStatement methodsFor: 'printing' stamp: 'dgd 27/May/2002 23:19:00'!
 printOn: aStream 
 	super printOn: aStream.
 	aStream nextPutAll: ' ''';
@@ -2901,7 +2905,7 @@ printOn: aStream
 				ifTrue: [' (connected)']
 				ifFalse: [' (not connected)'])! !
 
-!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:13:20'!
+!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:13:20'!
 sqlAllocStmt
 	| h |
 	h := SQLHSTMT new.
@@ -2911,7 +2915,7 @@ sqlAllocStmt
 		statement: h.
 	^h! !
 
-!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:14:09'!
+!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:14:09'!
 sqlBindParam: index argType: argType sqlType: sqlType columnSize: colSize digits: digits value: value length: length
 	| sqlLength |
 	sqlLength := SQLInteger new.
@@ -2923,7 +2927,7 @@ sqlBindParam: index argType: argType sqlType: sqlType columnSize: colSize digits
 	) statement: handle.
 ! !
 
-!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:14:18'!
+!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:14:18'!
 sqlDescribeParam: index
 	"Describe the given parameter."
 	| dataType paramSize digits nullable |
@@ -2942,26 +2946,26 @@ sqlDescribeParam: index
 		nullable: nullable value
 ! !
 
-!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:04:56'!
+!ODBCStatement methodsFor: 'sql helpers' stamp: 'OA 9/Jan/2026 22:41:08'!
 sqlExecDirect: queryString
 	connection checkSQLReturn: (ODBCLibrary default 
 		sqlExecDirect: handle statement: queryString length: queryString size
 	) statement: handle.
 ! !
 
-!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:05:02'!
+!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:05:02'!
 sqlExecute
 	connection
 		checkSQLReturn: (ODBCLibrary default sqlExecute: handle)
 		statement: handle.! !
 
-!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:05:07'!
+!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:05:07'!
 sqlGetTypeInfo: dataType
 	connection checkSQLReturn: (ODBCLibrary default 
 		sqlGetTypeInfo: handle with: dataType
 	) statement: handle! !
 
-!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:05:14'!
+!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:05:14'!
 sqlNumParams
 	"Answers the number of parameters in the statement"
 	| count |
@@ -2972,25 +2976,25 @@ sqlNumParams
 	^count value
 ! !
 
-!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:05:23'!
+!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:05:23'!
 sqlPrepare: queryString
 	connection checkSQLReturn: (ODBCLibrary default 
 		sqlPrepare: handle statement: queryString length: queryString size
 	) statement: handle.
 ! !
 
-!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 11/13/2023 16:05:27'!
+!ODBCStatement methodsFor: 'sql helpers' stamp: 'jfr 13/Nov/2023 16:05:27'!
 sqlSetStmtAttr: attr value: value length: length
 	connection checkSQLReturn: (ODBCLibrary default 
 			sqlSetStmtAttr: handle name: attr value: value length: length
 	) statement: handle.
 ! !
 
-!ODBCStatement class methodsFor: 'instance creation' stamp: 'dgd 5/27/2002 22:17'!
+!ODBCStatement class methodsFor: 'instance creation' stamp: 'dgd 27/May/2002 22:17:00'!
 connection: aConnection query: aString 
 	^ self new initializeConnection: aConnection query: aString ! !
 
-!ODBCPreparedStatement methodsFor: 'executing' stamp: 'ar 8/10/2008 18:02'!
+!ODBCPreparedStatement methodsFor: 'executing' stamp: 'ar 10/Aug/2008 18:02:00'!
 execute: args
 	"Execute the query with the given arguments and answer the result"
 	self checkConnected.
@@ -2998,12 +3002,12 @@ execute: args
 	self sqlExecute.
 	^ODBCResultSet connection: connection statement: self! !
 
-!ODBCPreparedStatement methodsFor: 'initialization' stamp: 'ar 8/10/2008 18:00'!
+!ODBCPreparedStatement methodsFor: 'initialization' stamp: 'ar 10/Aug/2008 18:00:00'!
 initializeConnection: aConnection query: aString 
 	super initializeConnection: aConnection query: aString.
 	self sqlPrepare: query.! !
 
-!Object methodsFor: '*odbc' stamp: 'rjl 9/4/2008 15:40'!
+!Object methodsFor: '*odbc' stamp: 'rjl 4/Sep/2008 15:40:00'!
 isExternalAddress
 	"Return true if the receiver describes an object in the outside world"
 	^ false! !


### PR DESCRIPTION
Tested with PostgreSQL

**fix:** `ODBCStatement >> Execute:` now supports SQL request with Unicode characters,
**fix:** `ODBCColumn >> stringFromBuffer` now supports SQL columns with Unicode Characters.  

An SQL query can now return strings containing special characters such as accented characters.

Special characters can be used in the conditions of an SQL query : `SELECT * FROM my_table WHERE first_name = 'Gérard'`

